### PR TITLE
ci: update push-master and release to use token

### DIFF
--- a/.github/workflows/push-master.yaml
+++ b/.github/workflows/push-master.yaml
@@ -18,7 +18,10 @@ jobs:
         - uses: actions/setup-node@v1
           with:
             node-version: ${{ matrix.node-version }}
+            registry-url: "https://registry.npmjs.org"
         - run: yarn install --frozen-lockfile
+          env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
         - run: yarn lint
         - run: yarn build
         - run: yarn test

--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -18,8 +18,10 @@ jobs:
         - uses: actions/setup-node@v1
           with:
             node-version: ${{ matrix.node-version }}
-        - run: yarn
+            registry-url: "https://registry.npmjs.org"
         - run: yarn install --frozen-lockfile
+          env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
         - run: yarn lint
         - run: yarn build
         - run: yarn test


### PR DESCRIPTION
Updates the ci workflows for push-master and push-release to use the npm_js token for package registry auth.
