### PR TITLE
fix: use expandContext in jsonld.frame operation

### DIFF
--- a/src/BbsBlsSignature2020.ts
+++ b/src/BbsBlsSignature2020.ts
@@ -318,7 +318,11 @@ export class BbsBlsSignature2020 extends suites.LinkedDataProof {
         "@embed": "@always",
         id: verificationMethod
       },
-      { documentLoader, compactToRelative: false }
+      {
+        documentLoader,
+        compactToRelative: false,
+        expandContext: SECURITY_CONTEXT_URL
+      }
     );
     if (!result) {
       throw new Error(`Verification method ${verificationMethod} not found.`);

--- a/src/BbsBlsSignatureProof2020.ts
+++ b/src/BbsBlsSignatureProof2020.ts
@@ -367,7 +367,11 @@ export class BbsBlsSignatureProof2020 extends suites.LinkedDataProof {
         "@embed": "@always",
         id: verificationMethod
       },
-      { documentLoader, compactToRelative: false }
+      {
+        documentLoader,
+        compactToRelative: false,
+        expandContext: SECURITY_CONTEXT_URL
+      }
     );
     if (!result) {
       throw new Error(`Verification method ${verificationMethod} not found.`);


### PR DESCRIPTION
Upstream consumption of this library was failing due to the frame operation associated with fetching the verification method, not being able to correctly frame the retrieved document.

## Description

Upstream consumption of this library was failing due to the frame operation associated with fetching the verification method

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

Bug fix

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
