### PR TITLE
feat: use from key pair method

### DIFF
--- a/__tests__/BbsBlsSignature2020.spec.ts
+++ b/__tests__/BbsBlsSignature2020.spec.ts
@@ -53,7 +53,7 @@ describe("BbsBlsSignature2020", () => {
 
   it("should verify with jsigs", async () => {
     const verificationResult = await jsigs.verify(testSignedDocument, {
-      suite: new BbsBlsSignature2020({ key }),
+      suite: new BbsBlsSignature2020(),
       purpose: new jsigs.purposes.AssertionProofPurpose(),
       documentLoader: customLoader,
       compactProof: false,
@@ -65,7 +65,7 @@ describe("BbsBlsSignature2020", () => {
 
   it("should verify verifiable credential with jsigs", async () => {
     const verificationResult = await jsigs.verify(testSignedVcDocument, {
-      suite: new BbsBlsSignature2020({ key }),
+      suite: new BbsBlsSignature2020(),
       purpose: new jsigs.purposes.AssertionProofPurpose(),
       documentLoader: customLoader,
       compactProof: false,
@@ -77,7 +77,7 @@ describe("BbsBlsSignature2020", () => {
 
   it("should not verify bad sig with jsigs", async () => {
     const verificationResult = await jsigs.verify(testBadSignedDocument, {
-      suite: new BbsBlsSignature2020({ key }),
+      suite: new BbsBlsSignature2020(),
       purpose: new jsigs.purposes.AssertionProofPurpose(),
       documentLoader: customLoader,
       compactProof: false,

--- a/__tests__/BbsBlsSignatureProof2020.spec.ts
+++ b/__tests__/BbsBlsSignatureProof2020.spec.ts
@@ -100,10 +100,7 @@ describe("BbsBlsSignatureProof2020", () => {
   });
 
   it("should verify derived proof", async () => {
-    const suite = new BbsBlsSignatureProof2020({
-      useNativeCanonize: false,
-      key
-    });
+    const suite = new BbsBlsSignatureProof2020();
     let document = { ...testProofDocument };
     let proof = {
       "@context": jsigs.SECURITY_CONTEXT_URL,
@@ -120,10 +117,7 @@ describe("BbsBlsSignatureProof2020", () => {
   });
 
   it("should verify partial derived proof", async () => {
-    const suite = new BbsBlsSignatureProof2020({
-      useNativeCanonize: false,
-      key
-    });
+    const suite = new BbsBlsSignatureProof2020();
     let document = { ...testPartialProofDocument };
     let proof = {
       "@context": jsigs.SECURITY_CONTEXT_URL,
@@ -140,10 +134,7 @@ describe("BbsBlsSignatureProof2020", () => {
   });
 
   it("should verify partial derived proof from vc", async () => {
-    const suite = new BbsBlsSignatureProof2020({
-      useNativeCanonize: false,
-      key
-    });
+    const suite = new BbsBlsSignatureProof2020();
     let document = { ...testPartialVcProof };
     let proof = {
       "@context": jsigs.SECURITY_CONTEXT_URL,
@@ -160,10 +151,7 @@ describe("BbsBlsSignatureProof2020", () => {
   });
 
   it("should not verify partial derived proof with bad proof", async () => {
-    const suite = new BbsBlsSignatureProof2020({
-      useNativeCanonize: false,
-      key
-    });
+    const suite = new BbsBlsSignatureProof2020();
     let document = { ...testBadPartialProofDocument };
     let proof = {
       "@context": jsigs.SECURITY_CONTEXT_URL,

--- a/__tests__/__fixtures__/data/did_example_489398593_test.json
+++ b/__tests__/__fixtures__/data/did_example_489398593_test.json
@@ -1,7 +1,7 @@
 {
-    "@context": "https://w3id.org/security/v2",
-    "id": "did:example:489398593#test",
-    "type": "BLSVerificationKey2020",
-    "controller": "did:example:489398593",
-    "publicKeyBase58": "5ctMjosGpHc3GTpB5mGUx7dNzm4W7NUf9FNnCXJxLL2xx98vEPgoSFxYzf8cypm3Bvtk7VhX7GEZJ2B65kchGiezqdTvrScc8hfwNnpX9mE21rGMo9XcJ4rHmbKPPUPT3Ghcd1rFnCFCDaFQ7oZ3Y64hFpwXGVmFz4BCxXqvf36eXUBnUFG64mV1keRsttSHNfZU66dGhVx3JMa1N3sn66nqGCujRKBtYqKb29kA4HnfsXj9aSXCJsxa795h6Kcb5un4be"
+  "@context": "https://w3id.org/security/v2",
+  "id": "did:example:489398593#test",
+  "type": "Bls12381G2Key2020",
+  "controller": "did:example:489398593",
+  "publicKeyBase58": "TXNALMsWD88T9SzbRfLU1GC6VeYVb9f1ivBuAL4mkbLHBTmc3U1T7P8eSDYM9QBLRGk6QDs7XWj62PLvMvBmRKTrcPF9LbLHjN3Jp9vJ8ZfUzTUXMxZ2xNyhRxRZn4uMHv"
 }

--- a/__tests__/deriveProof.spec.ts
+++ b/__tests__/deriveProof.spec.ts
@@ -12,7 +12,6 @@
  */
 
 import {
-  exampleBls12381KeyPair,
   testRevealDocument,
   testSignedDocument,
   customLoader,
@@ -20,19 +19,13 @@ import {
   testRevealVcDocument
 } from "./__fixtures__";
 
-import {
-  Bls12381G2KeyPair,
-  BbsBlsSignatureProof2020,
-  deriveProof
-} from "../src/index";
-
-const key = new Bls12381G2KeyPair(exampleBls12381KeyPair);
+import { BbsBlsSignatureProof2020, deriveProof } from "../src/index";
 
 describe("BbsBlsSignatureProof2020", () => {
   it("should derive proof", async () => {
     jest.setTimeout(30000);
     const result = await deriveProof(testSignedDocument, testRevealDocument, {
-      suite: new BbsBlsSignatureProof2020({ useNativeCanonize: false, key }),
+      suite: new BbsBlsSignatureProof2020(),
       documentLoader: customLoader,
       compactProof: false
     });
@@ -42,7 +35,7 @@ describe("BbsBlsSignatureProof2020", () => {
   it("should derive proof revealing all statements", async () => {
     jest.setTimeout(30000);
     const result = await deriveProof(testSignedDocument, testRevealDocument, {
-      suite: new BbsBlsSignatureProof2020({ useNativeCanonize: false, key }),
+      suite: new BbsBlsSignatureProof2020(),
       documentLoader: customLoader,
       compactProof: false
     });
@@ -55,7 +48,7 @@ describe("BbsBlsSignatureProof2020", () => {
       testSignedVcDocument,
       testRevealVcDocument,
       {
-        suite: new BbsBlsSignatureProof2020({ useNativeCanonize: false, key }),
+        suite: new BbsBlsSignatureProof2020(),
         documentLoader: customLoader,
         compactProof: false
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
-    "@mattrglobal/bls12381-key-pair": "0.1.0",
+    "@mattrglobal/bls12381-key-pair": "0.2.0",
     "@mattrglobal/node-bbs-signatures": "0.7.0",
     "@stablelib/random": "1.0.0",
     "bs58": "4.0.1",

--- a/src/BbsBlsSignature2020.ts
+++ b/src/BbsBlsSignature2020.ts
@@ -24,6 +24,7 @@ import {
   SuiteSignOptions
 } from "./types";
 import { w3cDate } from "./w3cDate";
+import { Bls12381G2KeyPair } from "@mattrglobal/bls12381-key-pair";
 
 /**
  * A BBS+ signature suite for use with BLS12-381 key pairs
@@ -33,7 +34,7 @@ export class BbsBlsSignature2020 extends suites.LinkedDataProof {
    * Default constructor
    * @param options {SignatureSuiteOptions} options for constructing the signature suite
    */
-  constructor(options: SignatureSuiteOptions) {
+  constructor(options: SignatureSuiteOptions = {}) {
     const {
       verificationMethod,
       signer,
@@ -50,6 +51,7 @@ export class BbsBlsSignature2020 extends suites.LinkedDataProof {
     }
     super({ type: "BbsBlsSignature2020" });
 
+    this.LDKeyClass = Bls12381G2KeyPair;
     this.signer = signer;
     this.verificationMethod = verificationMethod;
     this.proofSignatureKey = "signature";

--- a/yarn.lock
+++ b/yarn.lock
@@ -594,10 +594,10 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@mattrglobal/bls12381-key-pair@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.npmjs.org/@mattrglobal/bls12381-key-pair/-/bls12381-key-pair-0.1.0.tgz#562160e3138bc12110f20fb5d2a312a71032f0ef"
-  integrity sha512-NN44V4U0JhGOcZ/gOW4HpWSi4VZMOGSTW6MXVkgktijavN/CRyg2lGGJIZdNGxf5HMbVoo6LaNNKFqxXluusqA==
+"@mattrglobal/bls12381-key-pair@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/@mattrglobal/bls12381-key-pair/-/bls12381-key-pair-0.2.0.tgz#b94b0659c1be6a1ee490ce9e21d153f6bc627eff"
+  integrity sha512-gUV/egf+xlugQdWVTl9Rcdu8EnM8CjbTQ9NuauFnJBVW1Vb2GUnNorz+ga0KnhrsjXEQpOfcQNaP+YX0xWdJog==
   dependencies:
     "@mattrglobal/node-bbs-signatures" "0.7.0"
     bs58 "4.0.1"


### PR DESCRIPTION
## Description

Simplifies the top level api of the suites by using the .from() method for the key class to load the public key from the retrieved verification method

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

Simplified top level api

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
