### PR TITLE
feat: add support for bbs-signatures library

### DIFF
--- a/__tests__/BbsBlsSignatureProof2020.spec.ts
+++ b/__tests__/BbsBlsSignatureProof2020.spec.ts
@@ -32,7 +32,6 @@ const key = new Bls12381G2KeyPair(exampleBls12381KeyPair);
 
 describe("BbsBlsSignatureProof2020", () => {
   it("should derive proof", async () => {
-    jest.setTimeout(30000);
     const suite = new BbsBlsSignatureProof2020({
       useNativeCanonize: false,
       key
@@ -55,7 +54,6 @@ describe("BbsBlsSignatureProof2020", () => {
   });
 
   it("should derive proof revealing all statements", async () => {
-    jest.setTimeout(30000);
     const suite = new BbsBlsSignatureProof2020({
       useNativeCanonize: false,
       key
@@ -78,7 +76,6 @@ describe("BbsBlsSignatureProof2020", () => {
   });
 
   it("should derive proof from vc", async () => {
-    jest.setTimeout(30000);
     const suite = new BbsBlsSignatureProof2020({
       useNativeCanonize: false,
       key
@@ -124,12 +121,15 @@ describe("BbsBlsSignatureProof2020", () => {
       ...testPartialProofDocument.proof
     };
     delete document.proof;
+    console.log("Document: ", document);
+    console.log("Proof: ", proof);
     const result = await suite.verifyProof({
       document,
       proof,
       documentLoader: customLoader,
       purpose: new jsigs.purposes.AssertionProofPurpose()
     });
+    console.log(result);
     expect(result.verified).toBeTruthy();
   });
 
@@ -141,12 +141,15 @@ describe("BbsBlsSignatureProof2020", () => {
       ...testPartialVcProof.proof
     };
     delete document.proof;
+    console.log("Document: ", document);
+    console.log("Proof: ", proof);
     const result = await suite.verifyProof({
       document,
       proof,
       documentLoader: customLoader,
       purpose: new jsigs.purposes.AssertionProofPurpose()
     });
+    console.log(result);
     expect(result.verified).toBeTruthy();
   });
 

--- a/__tests__/BbsBlsSignatureProof2020.spec.ts
+++ b/__tests__/BbsBlsSignatureProof2020.spec.ts
@@ -121,15 +121,12 @@ describe("BbsBlsSignatureProof2020", () => {
       ...testPartialProofDocument.proof
     };
     delete document.proof;
-    console.log("Document: ", document);
-    console.log("Proof: ", proof);
     const result = await suite.verifyProof({
       document,
       proof,
       documentLoader: customLoader,
       purpose: new jsigs.purposes.AssertionProofPurpose()
     });
-    console.log(result);
     expect(result.verified).toBeTruthy();
   });
 
@@ -141,15 +138,12 @@ describe("BbsBlsSignatureProof2020", () => {
       ...testPartialVcProof.proof
     };
     delete document.proof;
-    console.log("Document: ", document);
-    console.log("Proof: ", proof);
     const result = await suite.verifyProof({
       document,
       proof,
       documentLoader: customLoader,
       purpose: new jsigs.purposes.AssertionProofPurpose()
     });
-    console.log(result);
     expect(result.verified).toBeTruthy();
   });
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,8 @@ module.exports = {
   testRegex: [".spec.ts$"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   coveragePathIgnorePatterns: ["<rootDir>/__tests__"],
+  testEnvironment: "node",
   verbose: true,
   name: pack.name,
-  displayName: pack.name,
+  displayName: pack.name
 };

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "vc-js": "0.6.4"
   },
   "dependencies": {
-    "@mattrglobal/bbs-signatures": "^0.3.0",
+    "@mattrglobal/bbs-signatures": "0.3.0",
     "@mattrglobal/bls12381-key-pair": "0.3.0",
     "@stablelib/random": "1.0.0",
     "bs58": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
-    "@mattrglobal/bbs-signatures": "^0.2.1-unstable.49aee81",
+    "@mattrglobal/bbs-signatures": "^0.3.0",
     "@mattrglobal/bls12381-key-pair": "0.3.0",
     "@stablelib/random": "1.0.0",
     "bs58": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "lib"
   ],
   "scripts": {
-    "test": "jest",
+    "test": "NODE_OPTIONS='--max-old-space-size=8192' jest",
     "build": "tsc --pretty",
     "clean": "rm -rf lib/",
     "format": "prettier --write \"**/*.ts\" \"**/*.md\"  \"!**/lib/**\"",

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     "typescript": "3.7.5"
   },
   "dependencies": {
+    "@mattrglobal/bbs-signatures": "^0.2.1-unstable.49aee81",
     "@mattrglobal/bls12381-key-pair": "0.3.0",
-    "@mattrglobal/node-bbs-signatures": "0.8.0",
     "@stablelib/random": "1.0.0",
     "bs58": "4.0.1",
     "jsonld": "3.1.0",

--- a/src/BbsBlsSignatureProof2020.ts
+++ b/src/BbsBlsSignatureProof2020.ts
@@ -14,10 +14,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import jsonld from "jsonld";
 import { suites, SECURITY_CONTEXT_URL } from "jsonld-signatures";
-import {
-  blsCreateProof,
-  blsVerifyProof
-} from "@mattrglobal/node-bbs-signatures";
+import { blsCreateProof, blsVerifyProof } from "@mattrglobal/bbs-signatures";
 import {
   DeriveProofOptions,
   VerifyProofOptions,

--- a/yarn.lock
+++ b/yarn.lock
@@ -594,10 +594,12 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@mattrglobal/bbs-signatures@^0.2.1-unstable.49aee81":
-  version "0.2.1-unstable.b125983"
-  resolved "https://registry.yarnpkg.com/@mattrglobal/bbs-signatures/-/bbs-signatures-0.2.1-unstable.b125983.tgz#0b165c46dcb5cbf692b468992578ba5a33508490"
-  integrity sha512-IahQ7Xr7YCMKAm+bPXWiIs4T9BIUBDH8yN14/JkVumAsgHk0jnv/s/A99ocIS1xxyE/WrTtMw4/kmueQAOpXBg==
+"@mattrglobal/bbs-signatures@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@mattrglobal/bbs-signatures/-/bbs-signatures-0.3.0.tgz#3f39c5a5b495cf8e004efa8222f3377ec58eb337"
+  integrity sha512-ymTzzVNLRD1NZl6G0Yrkh2dr+17EPzDbdP4qiVyvrS3r4vAJnbXPB3gLYm74SMBmYXsMpZCb5nPWzkMtdeApLQ==
+  optionalDependencies:
+    "@mattrglobal/node-bbs-signatures" "0.9.0"
 
 "@mattrglobal/bls12381-key-pair@0.3.0":
   version "0.3.0"
@@ -611,6 +613,14 @@
   version "0.8.0"
   resolved "https://registry.npmjs.org/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.8.0.tgz#cc09b9da4db0b298e35f9313c4dcc9c69ab1f06f"
   integrity sha512-jIPNlexenUXiqmISyo2+LV6hfGHFJAbex9BUcj+HZxdUPdmca30jG5x06TvIC/TuF1AiSIqJ5YsqTLBWA4X3Ig==
+  dependencies:
+    neon-cli "0.4.0"
+    node-pre-gyp "0.14.0"
+
+"@mattrglobal/node-bbs-signatures@0.9.0":
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/@mattrglobal/node-bbs-signatures/-/node-bbs-signatures-0.9.0.tgz#e581988babfa06ab50f2ba4e068877420e84bf11"
+  integrity sha512-FGy5kucFie3g6sTGFTjp6e91VicDncRFIbpvgIqGDyySJZtgPCL1es6yhEPrWfTnbX3zcXQfdm1OWhFlBLWP9w==
   dependencies:
     neon-cli "0.4.0"
     node-pre-gyp "0.14.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -594,6 +594,11 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
+"@mattrglobal/bbs-signatures@^0.2.1-unstable.49aee81":
+  version "0.2.1-unstable.b125983"
+  resolved "https://registry.yarnpkg.com/@mattrglobal/bbs-signatures/-/bbs-signatures-0.2.1-unstable.b125983.tgz#0b165c46dcb5cbf692b468992578ba5a33508490"
+  integrity sha512-IahQ7Xr7YCMKAm+bPXWiIs4T9BIUBDH8yN14/JkVumAsgHk0jnv/s/A99ocIS1xxyE/WrTtMw4/kmueQAOpXBg==
+
 "@mattrglobal/bls12381-key-pair@0.3.0":
   version "0.3.0"
   resolved "https://registry.npmjs.org/@mattrglobal/bls12381-key-pair/-/bls12381-key-pair-0.3.0.tgz#e2237fa056e4840bc6ea770062255a040c4102a8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -594,7 +594,7 @@
     mkdirp "^0.5.1"
     rimraf "^2.5.2"
 
-"@mattrglobal/bbs-signatures@^0.3.0":
+"@mattrglobal/bbs-signatures@0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@mattrglobal/bbs-signatures/-/bbs-signatures-0.3.0.tgz#3f39c5a5b495cf8e004efa8222f3377ec58eb337"
   integrity sha512-ymTzzVNLRD1NZl6G0Yrkh2dr+17EPzDbdP4qiVyvrS3r4vAJnbXPB3gLYm74SMBmYXsMpZCb5nPWzkMtdeApLQ==
@@ -4142,7 +4142,12 @@ lodash.templatesettings@^4.0.0:
   dependencies:
     lodash._reinterpolate "^3.0.0"
 
-lodash@4.17.19, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.2.1, lodash@^4.3.0:
+lodash@4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
+  integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.2.1, lodash@^4.3.0:
   version "4.17.19"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==


### PR DESCRIPTION
Solves #57

## Description

Removes the dependency on `node-bbs-signatures` and adds a dependency on `bbs-signatures` which has the node fallback built in now.


- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

To allow this library to run in non-node environments (browser, wasm, non-wasm e.g. react native)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [ ] Squash
- [x] Rebase (REVIEW COMMITS)
