### PR TITLE
fix: json-ld context issue

### DIFF
--- a/__tests__/BbsBlsSignature2020.spec.ts
+++ b/__tests__/BbsBlsSignature2020.spec.ts
@@ -29,13 +29,10 @@ const key = new Bls12381G2KeyPair(exampleBls12381KeyPair);
 
 describe("BbsBlsSignature2020", () => {
   it("should sign with jsigs", async () => {
-    jest.setTimeout(30000);
     const signed = await jsigs.sign(testDocument, {
       suite: new BbsBlsSignature2020({ key }),
       purpose: new jsigs.purposes.AssertionProofPurpose(),
-      documentLoader: customLoader,
-      compactProof: false,
-      expansionMap: undefined
+      documentLoader: customLoader
     });
     expect(signed).toBeDefined();
   });
@@ -44,9 +41,7 @@ describe("BbsBlsSignature2020", () => {
     const signed = await jsigs.sign(testVcDocument, {
       suite: new BbsBlsSignature2020({ key }),
       purpose: new jsigs.purposes.AssertionProofPurpose(),
-      documentLoader: customLoader,
-      compactProof: false,
-      expansionMap: undefined
+      documentLoader: customLoader
     });
     expect(signed).toBeDefined();
   });
@@ -55,9 +50,7 @@ describe("BbsBlsSignature2020", () => {
     const verificationResult = await jsigs.verify(testSignedDocument, {
       suite: new BbsBlsSignature2020(),
       purpose: new jsigs.purposes.AssertionProofPurpose(),
-      documentLoader: customLoader,
-      compactProof: false,
-      expansionMap: undefined
+      documentLoader: customLoader
     });
     expect(verificationResult).toBeDefined();
     expect(verificationResult.verified).toBeTruthy();
@@ -67,9 +60,7 @@ describe("BbsBlsSignature2020", () => {
     const verificationResult = await jsigs.verify(testSignedVcDocument, {
       suite: new BbsBlsSignature2020(),
       purpose: new jsigs.purposes.AssertionProofPurpose(),
-      documentLoader: customLoader,
-      compactProof: false,
-      expansionMap: undefined
+      documentLoader: customLoader
     });
     expect(verificationResult).toBeDefined();
     expect(verificationResult.verified).toBeTruthy();
@@ -79,9 +70,7 @@ describe("BbsBlsSignature2020", () => {
     const verificationResult = await jsigs.verify(testBadSignedDocument, {
       suite: new BbsBlsSignature2020(),
       purpose: new jsigs.purposes.AssertionProofPurpose(),
-      documentLoader: customLoader,
-      compactProof: false,
-      expansionMap: undefined
+      documentLoader: customLoader
     });
     expect(verificationResult).toBeDefined();
     expect(verificationResult.verified).toBeFalsy();

--- a/__tests__/BbsBlsSignatureProof2020.spec.ts
+++ b/__tests__/BbsBlsSignatureProof2020.spec.ts
@@ -27,89 +27,85 @@ import {
 
 import jsigs from "jsonld-signatures";
 import { Bls12381G2KeyPair, BbsBlsSignatureProof2020 } from "../src/index";
+import { getProofs } from "../src/utilities";
 
 const key = new Bls12381G2KeyPair(exampleBls12381KeyPair);
 
 describe("BbsBlsSignatureProof2020", () => {
   it("should derive proof", async () => {
-    jest.setTimeout(30000);
     const suite = new BbsBlsSignatureProof2020({
       useNativeCanonize: false,
       key
     });
-    let document = { ...testSignedDocument };
-    let proof = {
-      "@context": jsigs.SECURITY_CONTEXT_URL,
-      ...testSignedDocument.proof
-    };
-    delete document.proof;
 
-    const result = await suite.deriveProof({
+    const { proofs, document } = await getProofs({
+      document: testSignedDocument,
+      proofType: suite.supportedDeriveProofType,
+      documentLoader: customLoader
+    });
+
+    let result: any = await suite.deriveProof({
       document,
-      proof,
+      proof: proofs[0],
       revealDocument: testRevealDocument,
-      documentLoader: customLoader,
-      compactProof: false
+      documentLoader: customLoader
     });
     expect(result).toBeDefined();
   });
 
   it("should derive proof revealing all statements", async () => {
-    jest.setTimeout(30000);
     const suite = new BbsBlsSignatureProof2020({
       useNativeCanonize: false,
       key
     });
-    let document = { ...testSignedDocument };
-    let proof = {
-      "@context": jsigs.SECURITY_CONTEXT_URL,
-      ...testSignedDocument.proof
-    };
-    delete document.proof;
+
+    const { proofs, document } = await getProofs({
+      document: testSignedDocument,
+      proofType: suite.supportedDeriveProofType,
+      documentLoader: customLoader
+    });
 
     const result = await suite.deriveProof({
       document,
-      proof,
+      proof: proofs[0],
       revealDocument: testRevealAllDocument,
-      documentLoader: customLoader,
-      compactProof: false
+      documentLoader: customLoader
     });
     expect(result).toBeDefined();
   });
 
   it("should derive proof from vc", async () => {
-    jest.setTimeout(30000);
     const suite = new BbsBlsSignatureProof2020({
       useNativeCanonize: false,
       key
     });
-    let document = { ...testSignedVcDocument };
-    let proof = {
-      "@context": jsigs.SECURITY_CONTEXT_URL,
-      ...testSignedVcDocument.proof
-    };
-    delete document.proof;
+
+    const { proofs, document } = await getProofs({
+      document: testSignedVcDocument,
+      proofType: suite.supportedDeriveProofType,
+      documentLoader: customLoader
+    });
+
     const result = await suite.deriveProof({
       document,
-      proof,
+      proof: proofs[0],
       revealDocument: testRevealVcDocument,
-      documentLoader: customLoader,
-      compactProof: false
+      documentLoader: customLoader
     });
     expect(result).toBeDefined();
   });
 
   it("should verify derived proof", async () => {
     const suite = new BbsBlsSignatureProof2020();
-    let document = { ...testProofDocument };
-    let proof = {
-      "@context": jsigs.SECURITY_CONTEXT_URL,
-      ...testProofDocument.proof
-    };
-    delete document.proof;
+
+    const { proofs, document } = await getProofs({
+      document: testProofDocument,
+      documentLoader: customLoader
+    });
+
     const result = await suite.verifyProof({
       document,
-      proof,
+      proof: proofs[0],
       documentLoader: customLoader,
       purpose: new jsigs.purposes.AssertionProofPurpose()
     });
@@ -118,15 +114,15 @@ describe("BbsBlsSignatureProof2020", () => {
 
   it("should verify partial derived proof", async () => {
     const suite = new BbsBlsSignatureProof2020();
-    let document = { ...testPartialProofDocument };
-    let proof = {
-      "@context": jsigs.SECURITY_CONTEXT_URL,
-      ...testPartialProofDocument.proof
-    };
-    delete document.proof;
+
+    const { proofs, document } = await getProofs({
+      document: testPartialProofDocument,
+      documentLoader: customLoader
+    });
+
     const result = await suite.verifyProof({
       document,
-      proof,
+      proof: proofs[0],
       documentLoader: customLoader,
       purpose: new jsigs.purposes.AssertionProofPurpose()
     });
@@ -135,15 +131,15 @@ describe("BbsBlsSignatureProof2020", () => {
 
   it("should verify partial derived proof from vc", async () => {
     const suite = new BbsBlsSignatureProof2020();
-    let document = { ...testPartialVcProof };
-    let proof = {
-      "@context": jsigs.SECURITY_CONTEXT_URL,
-      ...testPartialVcProof.proof
-    };
-    delete document.proof;
+
+    const { proofs, document } = await getProofs({
+      document: testPartialVcProof,
+      documentLoader: customLoader
+    });
+
     const result = await suite.verifyProof({
       document,
-      proof,
+      proof: proofs[0],
       documentLoader: customLoader,
       purpose: new jsigs.purposes.AssertionProofPurpose()
     });
@@ -152,15 +148,15 @@ describe("BbsBlsSignatureProof2020", () => {
 
   it("should not verify partial derived proof with bad proof", async () => {
     const suite = new BbsBlsSignatureProof2020();
-    let document = { ...testBadPartialProofDocument };
-    let proof = {
-      "@context": jsigs.SECURITY_CONTEXT_URL,
-      ...testBadPartialProofDocument.proof
-    };
-    delete document.proof;
+
+    const { proofs, document } = await getProofs({
+      document: testBadPartialProofDocument,
+      documentLoader: customLoader
+    });
+
     const result = await suite.verifyProof({
       document,
-      proof,
+      proof: proofs[0],
       documentLoader: customLoader,
       purpose: new jsigs.purposes.AssertionProofPurpose()
     });

--- a/__tests__/__fixtures__/contexts/lds-bbsbls2020-v0.0.json
+++ b/__tests__/__fixtures__/contexts/lds-bbsbls2020-v0.0.json
@@ -3,8 +3,95 @@
     "@version": 1.1,
     "id": "@id",
     "type": "@type",
-    "ldssk": "https://w3c-ccg.github.io/lds-bbsbls2020/contexts/#",
-    "BbsBlsSignature2020": "ldssk:BbsBlsSignature2020",
-    "Bls12381VerificationKey2020": "ldssk:Bls12381VerificationKey2020"
+    "ldssk": "https://w3c-ccg.github.io/ldp-bbs2020/context/v1#",
+    "BbsBlsSignature2020": {
+      "@id": "https://w3c-ccg.github.io/ldp-bbs2020/context/v1#BbsBlsSignature2020",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "proofValue": "sec:proofValue",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "sec": "https://w3id.org/security#",
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+    "BbsBlsSignatureProof2020": {
+      "@id": "https://w3c-ccg.github.io/ldp-bbs2020/context/v1#BbsBlsSignatureProof2020",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "sec": "https://w3id.org/security#",
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+    "Bls12381G2Key2020": "ldssk:Bls12381G2Key2020"
   }
 }

--- a/__tests__/__fixtures__/customDocumentLoader.ts
+++ b/__tests__/__fixtures__/customDocumentLoader.ts
@@ -13,15 +13,23 @@
 
 import jsonld from "jsonld";
 import { extendContextLoader } from "jsonld-signatures";
+import credentialContext from "./data/credential_vocab.json";
+import odrlContext from "./data/odrl.json";
 import bbsContext from "./contexts/lds-bbsbls2020-v0.0.json";
 import exampleDidKey from "./data/did_example_489398593_test.json";
 import exampleDidDoc from "./data/did_example_489398593.json";
+import exampleDidb34Key from "./data/did_example_b34ca6cd37bbf23_test.json";
+import exampleDidb34Doc from "./data/did_example_b34ca6cd37bbf23.json";
 import citizenVocab from "./data/citizen_vocab.json";
 
 export const documents: any = {
-  "https://w3c-ccg.github.io/lds-bbsbls2020/contexts": bbsContext,
+  "https://w3c-ccg.github.io/ldp-bbs2020/context/v1": bbsContext,
+  "https://www.w3.org/2018/credentials/v1": credentialContext,
+  "https://www.w3.org/ns/odrl.jsonld": odrlContext,
   "did:example:489398593#test": exampleDidKey,
   "did:example:489398593": exampleDidDoc,
+  "did:example:b34ca6cd37bbf23#test": exampleDidb34Key,
+  "did:example:b34ca6cd37bbf23": exampleDidb34Doc,
   "https://w3id.org/citizenship/v1": citizenVocab
 };
 

--- a/__tests__/__fixtures__/data/credential_vocab.json
+++ b/__tests__/__fixtures__/data/credential_vocab.json
@@ -1,0 +1,307 @@
+{
+  "@context": {
+    "@version": 1.1,
+    "@protected": true,
+
+    "id": "@id",
+    "type": "@type",
+
+    "VerifiableCredential": {
+      "@id": "https://www.w3.org/2018/credentials#VerifiableCredential",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "cred": "https://www.w3.org/2018/credentials#",
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "credentialSchema": {
+          "@id": "cred:credentialSchema",
+          "@type": "@id",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "cred": "https://www.w3.org/2018/credentials#",
+
+            "JsonSchemaValidator2018": "cred:JsonSchemaValidator2018"
+          }
+        },
+        "credentialStatus": { "@id": "cred:credentialStatus", "@type": "@id" },
+        "credentialSubject": {
+          "@id": "cred:credentialSubject",
+          "@type": "@id"
+        },
+        "evidence": { "@id": "cred:evidence", "@type": "@id" },
+        "expirationDate": {
+          "@id": "cred:expirationDate",
+          "@type": "xsd:dateTime"
+        },
+        "holder": { "@id": "cred:holder", "@type": "@id" },
+        "issued": { "@id": "cred:issued", "@type": "xsd:dateTime" },
+        "issuer": { "@id": "cred:issuer", "@type": "@id" },
+        "issuanceDate": { "@id": "cred:issuanceDate", "@type": "xsd:dateTime" },
+        "proof": { "@id": "sec:proof", "@type": "@id", "@container": "@graph" },
+        "refreshService": {
+          "@id": "cred:refreshService",
+          "@type": "@id",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "cred": "https://www.w3.org/2018/credentials#",
+
+            "ManualRefreshService2018": "cred:ManualRefreshService2018"
+          }
+        },
+        "termsOfUse": { "@id": "cred:termsOfUse", "@type": "@id" },
+        "validFrom": { "@id": "cred:validFrom", "@type": "xsd:dateTime" },
+        "validUntil": { "@id": "cred:validUntil", "@type": "xsd:dateTime" }
+      }
+    },
+
+    "VerifiablePresentation": {
+      "@id": "https://www.w3.org/2018/credentials#VerifiablePresentation",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "cred": "https://www.w3.org/2018/credentials#",
+        "sec": "https://w3id.org/security#",
+
+        "holder": { "@id": "cred:holder", "@type": "@id" },
+        "proof": { "@id": "sec:proof", "@type": "@id", "@container": "@graph" },
+        "verifiableCredential": {
+          "@id": "cred:verifiableCredential",
+          "@type": "@id",
+          "@container": "@graph"
+        }
+      }
+    },
+
+    "EcdsaSecp256k1Signature2019": {
+      "@id": "https://w3id.org/security#EcdsaSecp256k1Signature2019",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": { "@id": "sec:expiration", "@type": "xsd:dateTime" },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+
+    "EcdsaSecp256r1Signature2019": {
+      "@id": "https://w3id.org/security#EcdsaSecp256r1Signature2019",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": { "@id": "sec:expiration", "@type": "xsd:dateTime" },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+
+    "Ed25519Signature2018": {
+      "@id": "https://w3id.org/security#Ed25519Signature2018",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "id": "@id",
+        "type": "@type",
+
+        "sec": "https://w3id.org/security#",
+        "xsd": "http://www.w3.org/2001/XMLSchema#",
+
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": { "@id": "sec:expiration", "@type": "xsd:dateTime" },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+
+    "RsaSignature2018": {
+      "@id": "https://w3id.org/security#RsaSignature2018",
+      "@context": {
+        "@version": 1.1,
+        "@protected": true,
+
+        "challenge": "sec:challenge",
+        "created": {
+          "@id": "http://purl.org/dc/terms/created",
+          "@type": "xsd:dateTime"
+        },
+        "domain": "sec:domain",
+        "expires": { "@id": "sec:expiration", "@type": "xsd:dateTime" },
+        "jws": "sec:jws",
+        "nonce": "sec:nonce",
+        "proofPurpose": {
+          "@id": "sec:proofPurpose",
+          "@type": "@vocab",
+          "@context": {
+            "@version": 1.1,
+            "@protected": true,
+
+            "id": "@id",
+            "type": "@type",
+
+            "sec": "https://w3id.org/security#",
+
+            "assertionMethod": {
+              "@id": "sec:assertionMethod",
+              "@type": "@id",
+              "@container": "@set"
+            },
+            "authentication": {
+              "@id": "sec:authenticationMethod",
+              "@type": "@id",
+              "@container": "@set"
+            }
+          }
+        },
+        "proofValue": "sec:proofValue",
+        "verificationMethod": {
+          "@id": "sec:verificationMethod",
+          "@type": "@id"
+        }
+      }
+    },
+
+    "proof": {
+      "@id": "https://w3id.org/security#proof",
+      "@type": "@id",
+      "@container": "@graph"
+    }
+  }
+}

--- a/__tests__/__fixtures__/data/did_example_b34ca6cd37bbf23.json
+++ b/__tests__/__fixtures__/data/did_example_b34ca6cd37bbf23.json
@@ -1,0 +1,5 @@
+{
+  "@context": "https://w3id.org/security/v2",
+  "id": "did:example:b34ca6cd37bbf23",
+  "authentication": ["did:example:b34ca6cd37bbf23#test"]
+}

--- a/__tests__/__fixtures__/data/did_example_b34ca6cd37bbf23_test.json
+++ b/__tests__/__fixtures__/data/did_example_b34ca6cd37bbf23_test.json
@@ -1,0 +1,8 @@
+{
+  "@context": "https://w3id.org/security/v2",
+  "id": "did:example:b34ca6cd37bbf23#test",
+  "type": "Ed25519VerificationKey2018",
+  "controller": "did:example:b34ca6cd37bbf23",
+  "publicKeyBase58": "DggG1kT5JEFwTC6RJTsT6VQPgCz1qszCkX5Lv4nun98x",
+  "privateKeyBase58": "sSicNq6YBSzafzYDAcuduRmdHtnrZRJ7CbvjzdQhC45ewwvQeuqbM2dNwS9RCf6buUJGu6N3rBy6oLSpMwha8tc"
+}

--- a/__tests__/__fixtures__/data/odrl.json
+++ b/__tests__/__fixtures__/data/odrl.json
@@ -1,0 +1,301 @@
+{
+  "@context": {
+    "odrl": "http://www.w3.org/ns/odrl/2/",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "dct": "http://purl.org/dc/terms/",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "vcard": "http://www.w3.org/2006/vcard/ns#",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "schema": "http://schema.org/",
+    "cc": "http://creativecommons.org/ns#",
+    "uid": "@id",
+    "type": "@type",
+    "Policy": "odrl:Policy",
+    "Rule": "odrl:Rule",
+    "profile": {
+      "@type": "@id",
+      "@id": "odrl:profile"
+    },
+    "inheritFrom": {
+      "@type": "@id",
+      "@id": "odrl:inheritFrom"
+    },
+    "ConflictTerm": "odrl:ConflictTerm",
+    "conflict": {
+      "@type": "@vocab",
+      "@id": "odrl:conflict"
+    },
+    "perm": "odrl:perm",
+    "prohibit": "odrl:prohibit",
+    "invalid": "odrl:invalid",
+    "Agreement": "odrl:Agreement",
+    "Assertion": "odrl:Assertion",
+    "Offer": "odrl:Offer",
+    "Privacy": "odrl:Privacy",
+    "Request": "odrl:Request",
+    "Set": "odrl:Set",
+    "Ticket": "odrl:Ticket",
+    "Asset": "odrl:Asset",
+    "AssetCollection": "odrl:AssetCollection",
+    "relation": {
+      "@type": "@id",
+      "@id": "odrl:relation"
+    },
+    "hasPolicy": {
+      "@type": "@id",
+      "@id": "odrl:hasPolicy"
+    },
+    "target": {
+      "@type": "@id",
+      "@id": "odrl:target"
+    },
+    "output": {
+      "@type": "@id",
+      "@id": "odrl:output"
+    },
+    "partOf": {
+      "@type": "@id",
+      "@id": "odrl:partOf"
+    },
+    "source": {
+      "@type": "@id",
+      "@id": "odrl:source"
+    },
+    "Party": "odrl:Party",
+    "PartyCollection": "odrl:PartyCollection",
+    "function": {
+      "@type": "@vocab",
+      "@id": "odrl:function"
+    },
+    "PartyScope": "odrl:PartyScope",
+    "assignee": {
+      "@type": "@id",
+      "@id": "odrl:assignee"
+    },
+    "assigner": {
+      "@type": "@id",
+      "@id": "odrl:assigner"
+    },
+    "assigneeOf": {
+      "@type": "@id",
+      "@id": "odrl:assigneeOf"
+    },
+    "assignerOf": {
+      "@type": "@id",
+      "@id": "odrl:assignerOf"
+    },
+    "attributedParty": {
+      "@type": "@id",
+      "@id": "odrl:attributedParty"
+    },
+    "attributingParty": {
+      "@type": "@id",
+      "@id": "odrl:attributingParty"
+    },
+    "compensatedParty": {
+      "@type": "@id",
+      "@id": "odrl:compensatedParty"
+    },
+    "compensatingParty": {
+      "@type": "@id",
+      "@id": "odrl:compensatingParty"
+    },
+    "consentingParty": {
+      "@type": "@id",
+      "@id": "odrl:consentingParty"
+    },
+    "consentedParty": {
+      "@type": "@id",
+      "@id": "odrl:consentedParty"
+    },
+    "informedParty": {
+      "@type": "@id",
+      "@id": "odrl:informedParty"
+    },
+    "informingParty": {
+      "@type": "@id",
+      "@id": "odrl:informingParty"
+    },
+    "trackingParty": {
+      "@type": "@id",
+      "@id": "odrl:trackingParty"
+    },
+    "trackedParty": {
+      "@type": "@id",
+      "@id": "odrl:trackedParty"
+    },
+    "contractingParty": {
+      "@type": "@id",
+      "@id": "odrl:contractingParty"
+    },
+    "contractedParty": {
+      "@type": "@id",
+      "@id": "odrl:contractedParty"
+    },
+    "Action": "odrl:Action",
+    "action": {
+      "@type": "@vocab",
+      "@id": "odrl:action"
+    },
+    "includedIn": {
+      "@type": "@id",
+      "@id": "odrl:includedIn"
+    },
+    "implies": {
+      "@type": "@id",
+      "@id": "odrl:implies"
+    },
+    "Permission": "odrl:Permission",
+    "permission": {
+      "@type": "@id",
+      "@id": "odrl:permission"
+    },
+    "Prohibition": "odrl:Prohibition",
+    "prohibition": {
+      "@type": "@id",
+      "@id": "odrl:prohibition"
+    },
+    "obligation": {
+      "@type": "@id",
+      "@id": "odrl:obligation"
+    },
+    "use": "odrl:use",
+    "grantUse": "odrl:grantUse",
+    "aggregate": "odrl:aggregate",
+    "annotate": "odrl:annotate",
+    "anonymize": "odrl:anonymize",
+    "archive": "odrl:archive",
+    "concurrentUse": "odrl:concurrentUse",
+    "derive": "odrl:derive",
+    "digitize": "odrl:digitize",
+    "display": "odrl:display",
+    "distribute": "odrl:distribute",
+    "execute": "odrl:execute",
+    "extract": "odrl:extract",
+    "give": "odrl:give",
+    "index": "odrl:index",
+    "install": "odrl:install",
+    "modify": "odrl:modify",
+    "move": "odrl:move",
+    "play": "odrl:play",
+    "present": "odrl:present",
+    "print": "odrl:print",
+    "read": "odrl:read",
+    "reproduce": "odrl:reproduce",
+    "sell": "odrl:sell",
+    "stream": "odrl:stream",
+    "textToSpeech": "odrl:textToSpeech",
+    "transfer": "odrl:transfer",
+    "transform": "odrl:transform",
+    "translate": "odrl:translate",
+    "Duty": "odrl:Duty",
+    "duty": {
+      "@type": "@id",
+      "@id": "odrl:duty"
+    },
+    "consequence": {
+      "@type": "@id",
+      "@id": "odrl:consequence"
+    },
+    "remedy": {
+      "@type": "@id",
+      "@id": "odrl:remedy"
+    },
+    "acceptTracking": "odrl:acceptTracking",
+    "attribute": "odrl:attribute",
+    "compensate": "odrl:compensate",
+    "delete": "odrl:delete",
+    "ensureExclusivity": "odrl:ensureExclusivity",
+    "include": "odrl:include",
+    "inform": "odrl:inform",
+    "nextPolicy": "odrl:nextPolicy",
+    "obtainConsent": "odrl:obtainConsent",
+    "reviewPolicy": "odrl:reviewPolicy",
+    "uninstall": "odrl:uninstall",
+    "watermark": "odrl:watermark",
+    "Constraint": "odrl:Constraint",
+    "LogicalConstraint": "odrl:LogicalConstraint",
+    "constraint": {
+      "@type": "@id",
+      "@id": "odrl:constraint"
+    },
+    "refinement": {
+      "@type": "@id",
+      "@id": "odrl:refinement"
+    },
+    "Operator": "odrl:Operator",
+    "operator": {
+      "@type": "@vocab",
+      "@id": "odrl:operator"
+    },
+    "RightOperand": "odrl:RightOperand",
+    "rightOperand": "odrl:rightOperand",
+    "rightOperandReference": {
+      "@type": "xsd:anyURI",
+      "@id": "odrl:rightOperandReference"
+    },
+    "LeftOperand": "odrl:LeftOperand",
+    "leftOperand": {
+      "@type": "@vocab",
+      "@id": "odrl:leftOperand"
+    },
+    "unit": "odrl:unit",
+    "dataType": {
+      "@type": "xsd:anyType",
+      "@id": "odrl:datatype"
+    },
+    "status": "odrl:status",
+    "absolutePosition": "odrl:absolutePosition",
+    "absoluteSpatialPosition": "odrl:absoluteSpatialPosition",
+    "absoluteTemporalPosition": "odrl:absoluteTemporalPosition",
+    "absoluteSize": "odrl:absoluteSize",
+    "count": "odrl:count",
+    "dateTime": "odrl:dateTime",
+    "delayPeriod": "odrl:delayPeriod",
+    "deliveryChannel": "odrl:deliveryChannel",
+    "elapsedTime": "odrl:elapsedTime",
+    "event": "odrl:event",
+    "fileFormat": "odrl:fileFormat",
+    "industry": "odrl:industry:",
+    "language": "odrl:language",
+    "media": "odrl:media",
+    "meteredTime": "odrl:meteredTime",
+    "payAmount": "odrl:payAmount",
+    "percentage": "odrl:percentage",
+    "product": "odrl:product",
+    "purpose": "odrl:purpose",
+    "recipient": "odrl:recipient",
+    "relativePosition": "odrl:relativePosition",
+    "relativeSpatialPosition": "odrl:relativeSpatialPosition",
+    "relativeTemporalPosition": "odrl:relativeTemporalPosition",
+    "relativeSize": "odrl:relativeSize",
+    "resolution": "odrl:resolution",
+    "spatial": "odrl:spatial",
+    "spatialCoordinates": "odrl:spatialCoordinates",
+    "systemDevice": "odrl:systemDevice",
+    "timeInterval": "odrl:timeInterval",
+    "unitOfCount": "odrl:unitOfCount",
+    "version": "odrl:version",
+    "virtualLocation": "odrl:virtualLocation",
+    "eq": "odrl:eq",
+    "gt": "odrl:gt",
+    "gteq": "odrl:gteq",
+    "lt": "odrl:lt",
+    "lteq": "odrl:lteq",
+    "neq": "odrl:neg",
+    "isA": "odrl:isA",
+    "hasPart": "odrl:hasPart",
+    "isPartOf": "odrl:isPartOf",
+    "isAllOf": "odrl:isAllOf",
+    "isAnyOf": "odrl:isAnyOf",
+    "isNoneOf": "odrl:isNoneOf",
+    "or": "odrl:or",
+    "xone": "odrl:xone",
+    "and": "odrl:and",
+    "andSequence": "odrl:andSequence",
+    "policyUsage": "odrl:policyUsage"
+  }
+}

--- a/__tests__/__fixtures__/data/test_bad_partial_proof_document.json
+++ b/__tests__/__fixtures__/data/test_bad_partial_proof_document.json
@@ -9,7 +9,7 @@
       "email": "schema:email"
     },
     "https://w3id.org/security/v2",
-    "https://w3c-ccg.github.io/lds-bbsbls2020/contexts"
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
   ],
   "@type": "Person",
   "lastName": "Does",
@@ -17,19 +17,10 @@
   "id": "urn:bnid:_:c14n0",
   "proof": {
     "type": "BbsBlsSignatureProof2020",
-    "@context": "https://w3id.org/security/v2",
     "created": "2020-04-25T00:26:11Z",
     "verificationMethod": "did:example:489398593#test",
     "proofPurpose": "assertionMethod",
     "proof": "badNRdmxY/v6kFMJ49Y4tNtCmQK1ycU/GFqEsJSydeu3z0icyRnR7Up7kG/YBjJrgUUnDOBc4Bm8gBoOFfzu1rY1jwDWI5flVl3K+s7v5h+VSlQdWeHZPA8q7Y1mpCJLksmiigW6+ZAl/I9pol6xpNMq4oecqJmz3ZbXk4MX6WSj1oIDEQ+RgjE6gHB24ogAAAAAdI2rgDj2S93z0TLxPO3mpFR76H7srVmoncs4uH1Bl3INTK4aPdbS1GRoq9R9YgX2kgAAAAJhmY6QEDMqtDVKI90Ks6P3GLZG245Puvo5USUHumMxFw+hL4SERE3m6qtwdBBDD4H+gfVll3ha/1va6CuKOxtvC8HuSAyXmhGFPq8z91iPr5BdWSCSvIcz65bbN9R8KOSPdkJpJSePtiGNem6drQ8zAAAABSM+WfXNVDIK+HURPfFeM8ZHWrdxR//0u/NCuodBvSFfcFXEluMXXwfwKBHzPiC+dhKHLQ3pGgASk5xYVXfOAIkxB4kGGxSOfdJ+BaBM96TkEw2hrFBrXnjEKP/uMbUPzFEfJusTUINaNkMjLkqDftQKEAXCsUI0HPzGunMhvCvfJ+QzNfKEfernU12Hg+bblW8ZFIrWVyveQCn3MagxaEg=",
-    "revealStatements": [
-      0,
-      1,
-      2,
-      4,
-      6
-    ],
-    "totalStatements": 8,
     "nonce": "U6PA9o5iHMWHcnud1KfzPzjCNpFs+dy60CU7201yWQLmcSL5XDiiMJ6j9z81eGoLm/I="
   }
 }

--- a/__tests__/__fixtures__/data/test_bad_signed_document.json
+++ b/__tests__/__fixtures__/data/test_bad_signed_document.json
@@ -1,18 +1,21 @@
-{ 
-    "@context": [ { "schema": "http://schema.org/",
+{
+  "@context": [
+    {
+      "schema": "http://schema.org/",
       "name": "schema:name",
       "homepage": "schema:url",
-      "image": "schema:image" },
+      "image": "schema:image"
+    },
     "https://w3id.org/security/v2",
-    "https://w3c-ccg.github.io/lds-bbsbls2020/contexts" ],
-    "name": "John Doe",
-    "homepage": "https://domain.com/profile",
-    "proof":
-    { 
-      "type": "BbsBlsSignature2020",
-      "created": "2020-04-18T02:41:11Z",
-      "verificationMethod": "did:example:489398593#test",
-      "proofPurpose": "assertionMethod",
-      "signature": "cBJG+AYOEuLd3MwsOC1xyPRcmspso687W24zSvduShKbL0xCJk7f0rrEpKkBpYPHThU3f3gP0d4amCQ9QLkGT5Z9mw2r2MakfdliAhnVt/CvV1IEEyouFAqzCiEyfxhU1wAAAAAAAAAAAAAAAAAAAABT3s/8eZfUJrJNLFxMiMnIhYWQvkqA80eRpwTZKWjRUwAAAAAAAAAAAAAAAAAAAAADp+HUtElIe+t1Pb0tiqrodTEb+pU4i9tDihJBY0xODA==" 
-    }
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
+  ],
+  "name": "John Doe",
+  "homepage": "https://domain.com/profile",
+  "proof": {
+    "type": "BbsBlsSignature2020",
+    "created": "2020-04-18T02:41:11Z",
+    "verificationMethod": "did:example:489398593#test",
+    "proofPurpose": "assertionMethod",
+    "signature": "cBJG+AYOEuLd3MwsOC1xyPRcmspso687W24zSvduShKbL0xCJk7f0rrEpKkBpYPHThU3f3gP0d4amCQ9QLkGT5Z9mw2r2MakfdliAhnVt/CvV1IEEyouFAqzCiEyfxhU1wAAAAAAAAAAAAAAAAAAAABT3s/8eZfUJrJNLFxMiMnIhYWQvkqA80eRpwTZKWjRUwAAAAAAAAAAAAAAAAAAAAADp+HUtElIe+t1Pb0tiqrodTEb+pU4i9tDihJBY0xODA=="
   }
+}

--- a/__tests__/__fixtures__/data/test_document.json
+++ b/__tests__/__fixtures__/data/test_document.json
@@ -1,11 +1,13 @@
 {
-    "@context": [ "https://schema.org",
-                  "https://w3id.org/security/v2",
-                  "https://w3c-ccg.github.io/lds-bbsbls2020/contexts" ],
-    "@type": "Person",
-    "firstName": "Jane",
-    "lastName": "Does",
-    "jobTitle": "Professor",
-    "telephone": "(425) 123-4567",
-    "email": "jane.doe@example.com"
+  "@context": [
+    "https://schema.org",
+    "https://w3id.org/security/v2",
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
+  ],
+  "@type": "Person",
+  "firstName": "Jane",
+  "lastName": "Does",
+  "jobTitle": "Professor",
+  "telephone": "(425) 123-4567",
+  "email": "jane.doe@example.com"
 }

--- a/__tests__/__fixtures__/data/test_partial_proof_document.json
+++ b/__tests__/__fixtures__/data/test_partial_proof_document.json
@@ -2,7 +2,7 @@
   "@context": [
     "http://schema.org/",
     "https://w3id.org/security/v2",
-    "https://w3c-ccg.github.io/lds-bbsbls2020/contexts"
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
   ],
   "id": "urn:bnid:_:c14n0",
   "type": "Person",
@@ -10,11 +10,10 @@
   "lastName": "Does",
   "proof": {
     "type": "BbsBlsSignatureProof2020",
-    "@context": "https://w3id.org/security/v2",
-    "created": "2020-05-25T22:49:38Z",
+    "created": "2020-07-21T04:16:41Z",
     "verificationMethod": "did:example:489398593#test",
     "proofPurpose": "assertionMethod",
-    "proofValue": "AAkBV44EXaM9fq2thk930UkcADLgL7Z9cg7BPFb3EPgg09b/fGnh64mFohGYGQo99EsJ4bb3yZo9aBdrBmwrEijn5fzjkOp12NOOcepk66miCw+I7cfyTgL7njpd5y8x3DFz6Jk1uYaRBlHwOhvE4AH1C1UhyOW0aL5oZrm2WXbFLsng642+2T0x3t8s1WgOFRBavQAAAHSZkhqIc3q3a7NVAcyKQtH8rIVb1Mq3x6dI63LR8ynXPrVktxVRCnrWr5SUd/dXoYYAAAACCklntNAUfV+Ep84p3p8bREAlSrSGWmr+hLAYdsWEcUAikCkx0APLU265f2D4xwOjZZ4d7FE/sXLNNcAdaGFvM6hlXloVbQ6sNP/BHegl3CzAevlC7CMpmhithSmfWPwMhC8Ky+NVyc3F+HrCZV71ZAAAAAUSgikwleUuQQn7KVkCRG5KEkYWcj/HX+8WnerGw18RXw4NERJd2a2lrx9Rn3Sl8/eqU3i804GvYzfsMNo2G5P8CCoOAAoZztRJ7Ttt5M7PiMMBFZy+TQz4hfWr9ODBnBNqVHRG9CJgs9Y4ivQ5ZVm0+fVtx8RjPkCyhlEGTPNGiANYqCAJgRethcMonP/sHXLfDqp3TvgGazhkZGCXRkQU",
-    "nonce": "LSlkfDNxSbJqDw885WoNl2hMTriDh9Z8/GV870Mzi4lYlD4KsgMjs4jis70F2UgVr94="
+    "proofValue": "AAoCr4bKbF3tmEsDoM3HfKQw4UvF3gw+4HKtn1oqis/ZAPY52i8DU2HXtd7aR0wC7AVbaLc6XUVzCePhSFdCSyBLf+vyToCVcOpGXCaxB69vuSRYnNnXcVBtPRuLs6yt8P42R6V0pFiXGxFt/pOsUogzmSkXUq76z5kRE2oa8wYVj7g7fdNjdcT6jrUbaaRY6OlEowAAAHSHG4w2TQGpdpw2lWT9F359AkxYut7rJmU8MFhvoPwgnDp5JpM7A3mrRMuUuMxZ/hMAAAACBF/podNcLyo0Dy+TA7r7f+meT4W4ozce0OTn7AQHfyFXnWCbY+24sl8koinQlEms5Anc/KOvpvrs+WbeV/yGg7JNAXq+X1BZ/rM0RYwjEmySxjvhzBk8/iOfbuyKfHRdpoAjie7fYAeeDhg43n8nVwAAAAVZSEGRVMqU56ZIGTowCRzxXulLSD5C9D1tgxVmX8VDFUC8wsWIOUX9X5Oz1+nUUwB8YkvFyeKnG8QX36H8DyhBDiiSAMIV0vLeVlnZWtpbrzDUPYYftAqSUaHsAjQJ8pQRKUq3+k7/RVxnTWqc/PrI/P7lGcnKykb5fktZVfT8KRUOlS+jXVkRnP4z6G/IztTB2a4dLLBtzla9TW1tszTD",
+    "nonce": "5rxsQdyjX8rcfYuRAbZ8t6yhB9yJQM6PCI29sBky7kQbH07yqSe1N1YIC3xZr3gzK4w="
   }
 }

--- a/__tests__/__fixtures__/data/test_partial_proof_vc_document.json
+++ b/__tests__/__fixtures__/data/test_partial_proof_vc_document.json
@@ -1,7 +1,8 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://w3id.org/citizenship/v1"
+    "https://w3id.org/citizenship/v1",
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
   ],
   "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
   "type": ["PermanentResidentCard", "VerifiableCredential"],
@@ -20,11 +21,10 @@
   "issuer": "did:example:489398593",
   "proof": {
     "type": "BbsBlsSignatureProof2020",
-    "@context": "https://w3id.org/security/v2",
-    "created": "2020-05-25T23:07:10Z",
+    "created": "2020-07-21T04:21:26Z",
     "verificationMethod": "did:example:489398593#test",
     "proofPurpose": "assertionMethod",
-    "proofValue": "ABgA/4N3qygQRJlX3gmQOlJRGbO1KTXKQUmaN02xl+FiNZUDmGfa5OoKtg0RJ4wxxA08t3Vut61G/pq4yN0bygaFk5EJF6j7zFXmz9Vc7EdlDAvUkXqPaKA8inSBNv97HiZ1o5hIpoRnepW89p4JXPVrFi8XbDARSZpCg18GUuUMaPQLHKU82M/9l8tqqG1lKBOs+sRAAAAAdKRrRPj6zAz5LPZgDZJ0J2rNJjQI+JNYbV4AYEVwW37sxQ99aGGvmBk3DL0sod1V/gAAAAJMLYjmrb92zV087wO8UtFLwMj7qJuqV9VkMDghdrrc3BGtJuQgKx2GTrOb4CQxI1bf+iG0USjTktcjTlKv3X5spg3+ihOnyve0HnMWWggAW22j8b78jbl7lkYGJvzIXTzrVJ5KdYp3tXMDTAX7CLEXAAAACVY8oocA9Bz1w42F8Yv7UAPHv4pSvunXqndFOet3kWtzYHYEbO5gc42wPQtLmTtmqP6kUbQv6ruxzRmANulB8fUfy2jah/QeHKvsp907YDnSfo2wofRxa/vzsZnVriw0UmZnP0sYjbhmCkhoQZkxhqel3IkOF+H80wzvCKCl6eq5biEFMYA4bXpDX6Ap5/6WS5SSFaJRWxW+hpR/9EuQE11sGtk2W2Wn4eBrQUgVqYgPLI+U/ONaUJrh+GVJ/XXx7xxbAUf/NeQ/13AkTnYNn1fUdiOJ2oKl1lGr59udFq2tBBsyC3msTtQPYJS084355GRBur5jnzPNJ2W6Gu3ZqqQeRrVyw1gzdhVDNOE8KUm9OQ3AvCuxo8PHNrqzNvc6VA==",
-    "nonce": "37pdwue1a8FWLqgwCd0QJ0IJTFhp609KtxeCTWZGnfAVE+sOBDffYez+TY/bmVy+6z4="
+    "proofValue": "ABkB/wbvhFm/daKQXX5mYpKHLWWC705FWFS2eTEm5g+5A916OyD2iV+ISxAkNVRseQ+BzON3pRdPYWxBi4iMO4zXqm4gMPiMplSATjhsYHydZ8r2odigLDhoufpZBakB8x/D6sfzquBz7ov5M5pNkUW4pJiVD7vnRzKCgORXT4QoLUhJGnRUBeA2FzH8DSO7xaryCm+GAAAAdImv7O5lg0T24bi2smv5w6tRr8C0RNXYi+RFQ82Nkbxcqfek/fj1sYhH0uiF3PSogwAAAAJk3zuPqODgs0yV3VdWnl38HELRaXj+GL2evWGbPFfJkzunuVj46BY1VKKOzzVjP/sbPlf+KHOtF+mkXiSQM7F1oSOlaTKY5YZF9EaOMjpQhWEkmuozbGINGluG5F0amW2K2topkQ/Vb/BRDI2H+DUAAAAACWbnQ0wYMn367L/Xx6QT2GIAXD2z4Fz/tUqQYHlPbbKrLC0AbDnSQDAL6dH5OHGoBfsJ2wNgG9I8mtkvP6XP3ZYJWR4UVdihQCp04e2hXkY0pqsP+fItLMQrZyPTCuMWVzbi+rlNbkWOp2zWEi7kRhDNSp8E/azV3TPKKrxf4oLvLlSKPHu/+72/l0Puyv4vGwR3O3WF/2Fg1OCjdLwchPdN8ojrFCOcJjIlNQEzWsqnWSfAl8WYH0MiUnUa4hrdwVXOCZ5jNw//Yky0KkWLPeZ+IGRWGCJC04hv0AXaoVlTDyh7coolxKIyaxSkfJj1W5aCfYizjeCA0CBLleyziwUuXTEeLIhiPN+DyQyDvzdDQLQiOD+gdB1zXEL966Z/YQ==",
+    "nonce": "thlQKSZ48ATCZHk1DKKkuE+t02jJ/1hYWC3gtSVpMzpuHE/BQACpDaU8+t9POI1pyo8="
   }
 }

--- a/__tests__/__fixtures__/data/test_proof_document.json
+++ b/__tests__/__fixtures__/data/test_proof_document.json
@@ -1,9 +1,5 @@
 {
-  "@context": [
-    "http://schema.org/",
-    "https://w3id.org/security/v2",
-    "https://w3c-ccg.github.io/lds-bbsbls2020/contexts"
-  ],
+  "@context": ["http://schema.org/", "https://w3id.org/security/v2"],
   "id": "urn:bnid:_:c14n0",
   "type": "Person",
   "email": "jane.doe@example.com",
@@ -13,11 +9,10 @@
   "telephone": "(425) 123-4567",
   "proof": {
     "type": "BbsBlsSignatureProof2020",
-    "@context": "https://w3id.org/security/v2",
-    "created": "2020-05-25T22:49:38Z",
+    "created": "2020-07-21T04:16:41Z",
     "verificationMethod": "did:example:489398593#test",
     "proofPurpose": "assertionMethod",
-    "proofValue": "AAkB/4oxhQKow7T1W9iX8RYSV4W6+WexKBW56ecfgKSN9z3/L85pqdMQLFa7lxHonEiiIrMkODOdE7aeXaegz35i5K7wLd9QzuUxsTTcKQ+AYSzpvi6xacUsggAl1Go6fMI8ZK8rOnukhiiKWUaBcI33MyzC9VnqP5qQ0fZ2ymtX3BNi6QbfKdICCtAip2XteWrUXQAAAHSg+KVIw+RLyMKbEVq3EHSxCPQZ8FgWyLceDU3pnoj+vXsUKfyGBCKV1ug6/AMfu78AAAACSVGd9MwVlKS/UeeoajgD23ituIX1k3HPpnUFn7ncwEorL2ksncOUsnhDKmCEWQ902LqMKCUt2hcyjTF81inGo6DK8CSymX+e3AV/Jdj0lAHiFhHGQJN0qsp79kGuMgJnpCNxU5mEK4/k973NEG5N4gAAAAJP8MkQiTvubiyk0hHBhNdyD8HxphMGCNMuLdCFraFLtzzlk/0jJmB3K6UxJkc9Ul08IaPusXjJSwwZdji/HMru",
-    "nonce": "fmHRymGNI12VMo6T8PX1bIVCKmHf9AdVagUzXdPMvFs4W+kvjqqZ520nQMXvfYa/v28="
+    "proofValue": "AAoD/4XIHpCb/4necmgnauMPaGKoQiTfDmB3Gk+oX99V8qe/Os3X21NNnPrr5QusW1eizom+c5zIMi8uIprRuumLCpN/HpzbTYaYrts+R6wIoB9GtUOcBR3Pwp6avuPK1sO84YStE91pLu5zO64/OsHz2XsqMb3Qo3AL9drfwlhCOh+gzVuEkHtS38TxLvhru/I7BwAAAHSFWEOFEHY4bXwZZf8710RdkN2phd0A3DIi4fq+NMh0Bxx9vmBevt7LnaVln5so20UAAAACOkUnNGzLNxtWPYhS4hiVFf2D3mkQ2LaxaYsjz7Dvc8gz6ucnMMMYFGEsN4DwgrAk3BekfAb40RrzXPRWRWni3LXi4kbGx6BNlWB28L7LKrBBsgi64xALHEWXedU9mxCrz5fENJ3G45cx6Yh7ixHxMQAAAAJhQb1RFEBF0X1bggECt4ipbWwvKLuSECtJ5LmTcDDF4DinW96UfoR3ZZ3F3BR2km+uDWOi1dCT8t/aCmnIPUkM",
+    "nonce": "BOfgWqu5YfS13yGy/zEVrK8FNtV4ZjgJ2P3K5/CLxcntYHskookpehxWm2ccuUqJb9o="
   }
 }

--- a/__tests__/__fixtures__/data/test_reveal_all_document.json
+++ b/__tests__/__fixtures__/data/test_reveal_all_document.json
@@ -1,6 +1,4 @@
 {
-  "@context": ["http://schema.org/",
-  "https://w3id.org/security/v2",
-  "https://w3c-ccg.github.io/lds-bbsbls2020/contexts" ],
-    "@type": "Person"
+  "@context": ["http://schema.org/", "https://w3id.org/security/v2"],
+  "@type": "Person"
 }

--- a/__tests__/__fixtures__/data/test_reveal_document.json
+++ b/__tests__/__fixtures__/data/test_reveal_document.json
@@ -1,9 +1,11 @@
 {
-  "@context": ["http://schema.org/",
-  "https://w3id.org/security/v2",
-  "https://w3c-ccg.github.io/lds-bbsbls2020/contexts" ],
-    "@type": "Person",
-    "@explicit": true,
-    "firstName": "Jane",
-    "lastName": "Does"
+  "@context": [
+    "http://schema.org/",
+    "https://w3id.org/security/v2",
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
+  ],
+  "@type": "Person",
+  "@explicit": true,
+  "firstName": "Jane",
+  "lastName": "Does"
 }

--- a/__tests__/__fixtures__/data/test_signed_document.json
+++ b/__tests__/__fixtures__/data/test_signed_document.json
@@ -2,7 +2,7 @@
   "@context": [
     "https://schema.org",
     "https://w3id.org/security/v2",
-    "https://w3c-ccg.github.io/lds-bbsbls2020/contexts"
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
   ],
   "@type": "Person",
   "firstName": "Jane",
@@ -12,9 +12,9 @@
   "email": "jane.doe@example.com",
   "proof": {
     "type": "BbsBlsSignature2020",
-    "created": "2020-05-25T22:49:38Z",
+    "created": "2020-07-21T04:16:41Z",
     "verificationMethod": "did:example:489398593#test",
     "proofPurpose": "assertionMethod",
-    "signature": "jHQ22/z+kDiXSKMjuRtn/owTxNjpbauXyHVU2/1xZeGeCOr0qTNzf/z36u4JxZlhKIkgj/1UoOp9XiEQdO25JsGtNnmjKX/m69gPhbJM4O5NXiTGsctdnhrBLHqH4MG29zq9yshvabeSm7EtgSJjpQ=="
+    "proofValue": "pTy8PJCw93RrD+X55McbjHfrlW5SJYNhF84Eggafnlb2CH8QtfXfNsTnVuTQp8UfKKbKqOp6ASwv2kmKtXJJpK+n7+mNKMbeBqw/fuwbu5w/QjvCgYZH3WhlZq6zTmRN9MwO1lQOxntcnKP8xmaoAw=="
   }
 }

--- a/__tests__/__fixtures__/data/test_signed_document_ed25519.json
+++ b/__tests__/__fixtures__/data/test_signed_document_ed25519.json
@@ -1,0 +1,22 @@
+{
+  "@context": [
+    "https://schema.org",
+    "https://w3id.org/security/v2",
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
+  ],
+  "@type": "Person",
+  "firstName": "Jane",
+  "lastName": "Does",
+  "jobTitle": "Professor",
+  "telephone": "(425) 123-4567",
+  "email": "jane.doe@example.com",
+  "proof": [
+    {
+      "type": "Ed25519Signature2018",
+      "created": "2020-01-30T03:32:15Z",
+      "jws": "eyJhbGciOiJFZERTQSIsI...wRG2fNmAx60Vi4Ag",
+      "proofPurpose": "assertionMethod",
+      "verificationMethod": "did:example:28394728934792387#keys-7f83he7s8"
+    }
+  ]
+}

--- a/__tests__/__fixtures__/data/test_signed_document_multi_dif_proofs.json
+++ b/__tests__/__fixtures__/data/test_signed_document_multi_dif_proofs.json
@@ -1,0 +1,29 @@
+{
+  "@context": [
+    "https://schema.org",
+    "https://w3id.org/security/v2",
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
+  ],
+  "@type": "Person",
+  "firstName": "Jane",
+  "lastName": "Does",
+  "jobTitle": "Professor",
+  "telephone": "(425) 123-4567",
+  "email": "jane.doe@example.com",
+  "proof": [
+    {
+      "type": "BbsBlsSignature2020",
+      "created": "2020-07-21T04:16:41Z",
+      "verificationMethod": "did:example:489398593#test",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "pTy8PJCw93RrD+X55McbjHfrlW5SJYNhF84Eggafnlb2CH8QtfXfNsTnVuTQp8UfKKbKqOp6ASwv2kmKtXJJpK+n7+mNKMbeBqw/fuwbu5w/QjvCgYZH3WhlZq6zTmRN9MwO1lQOxntcnKP8xmaoAw=="
+    },
+    {
+      "type": "Ed25519Signature2018",
+      "created": "2020-01-30T03:32:15Z",
+      "jws": "eyJhbGciOiJFZERTQSIsI...wRG2fNmAx60Vi4Ag",
+      "proofPurpose": "assertionMethod",
+      "verificationMethod": "did:example:28394728934792387#keys-7f83he7s8"
+    }
+  ]
+}

--- a/__tests__/__fixtures__/data/test_signed_document_multi_proofs.json
+++ b/__tests__/__fixtures__/data/test_signed_document_multi_proofs.json
@@ -1,0 +1,29 @@
+{
+  "@context": [
+    "https://schema.org",
+    "https://w3id.org/security/v2",
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
+  ],
+  "@type": "Person",
+  "firstName": "Jane",
+  "lastName": "Does",
+  "jobTitle": "Professor",
+  "telephone": "(425) 123-4567",
+  "email": "jane.doe@example.com",
+  "proof": [
+    {
+      "type": "BbsBlsSignature2020",
+      "created": "2020-07-21T04:16:41Z",
+      "verificationMethod": "did:example:489398593#test",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "pTy8PJCw93RrD+X55McbjHfrlW5SJYNhF84Eggafnlb2CH8QtfXfNsTnVuTQp8UfKKbKqOp6ASwv2kmKtXJJpK+n7+mNKMbeBqw/fuwbu5w/QjvCgYZH3WhlZq6zTmRN9MwO1lQOxntcnKP8xmaoAw=="
+    },
+    {
+      "type": "BbsBlsSignature2020",
+      "created": "2020-07-21T04:16:41Z",
+      "verificationMethod": "did:example:489398593#test",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "pTy8PJCw93RrD+X55McbjHfrlW5SJYNhF84Eggafnlb2CH8QtfXfNsTnVuTQp8UfKKbKqOp6ASwv2kmKtXJJpK+n7+mNKMbeBqw/fuwbu5w/QjvCgYZH3WhlZq6zTmRN9MwO1lQOxntcnKP8xmaoAw=="
+    }
+  ]
+}

--- a/__tests__/__fixtures__/data/test_signed_vc.json
+++ b/__tests__/__fixtures__/data/test_signed_vc.json
@@ -1,7 +1,8 @@
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://w3id.org/citizenship/v1"
+    "https://w3id.org/citizenship/v1",
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
   ],
   "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
   "type": ["VerifiableCredential", "PermanentResidentCard"],
@@ -27,9 +28,9 @@
   },
   "proof": {
     "type": "BbsBlsSignature2020",
-    "created": "2020-05-25T23:07:10Z",
+    "created": "2020-07-21T04:21:26Z",
     "verificationMethod": "did:example:489398593#test",
     "proofPurpose": "assertionMethod",
-    "signature": "t+EZAcxZshLwmLUT7+jXS+U/4rJoBqMl81TixG9xavLQIvZWAgUlGK1g93ZxuhsRRv1p+NPC4yop7UHKgXwyVJNeyWQ6EQ0vtp/z3V/0Y2sPo9EpbxkzFyylROJRJYgVQMqJAlHX6sSTpfPPlqmiGA=="
+    "proofValue": "sIlFWyeeGPRtUCTh3A/6Qnirrld+I795JyV9Du8MI5UOaCHZRUeAF9jivF9CSwuIJDp+rd6gCqIZ2JKvl8pdrzkwE5/IP181azgUILtS5YRzANsisGcNIxC9gVaP8Vhz2KKNzjOpzG4eXG3Uf8SUZg=="
   }
 }

--- a/__tests__/__fixtures__/data/test_vc.json
+++ b/__tests__/__fixtures__/data/test_vc.json
@@ -1,28 +1,29 @@
 {
-    "@context": [
-      "https://www.w3.org/2018/credentials/v1",
-      "https://w3id.org/citizenship/v1"
-    ],
-    "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
-    "type": ["VerifiableCredential", "PermanentResidentCard"],
-    "issuer": "did:example:489398593",
-    "identifier": "83627465",
-    "name": "Permanent Resident Card",
-    "description": "Government of Example Permanent Resident Card.",
-    "issuanceDate": "2019-12-03T12:19:52Z",
-    "expirationDate": "2029-12-03T12:19:52Z",
-    "credentialSubject": {
-      "id": "did:example:b34ca6cd37bbf23",
-      "type": ["PermanentResident", "Person"],
-      "givenName": "JOHN",
-      "familyName": "SMITH",
-      "gender": "Male",
-      "image": "data:image/png;base64,iVBORw0KGgokJggg==",
-      "residentSince": "2015-01-01",
-      "lprCategory": "C09",
-      "lprNumber": "999-999-999",
-      "commuterClassification": "C1",
-      "birthCountry": "Bahamas",
-      "birthDate": "1958-07-17"
-    }
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/citizenship/v1",
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
+  ],
+  "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
+  "type": ["VerifiableCredential", "PermanentResidentCard"],
+  "issuer": "did:example:489398593",
+  "identifier": "83627465",
+  "name": "Permanent Resident Card",
+  "description": "Government of Example Permanent Resident Card.",
+  "issuanceDate": "2019-12-03T12:19:52Z",
+  "expirationDate": "2029-12-03T12:19:52Z",
+  "credentialSubject": {
+    "id": "did:example:b34ca6cd37bbf23",
+    "type": ["PermanentResident", "Person"],
+    "givenName": "JOHN",
+    "familyName": "SMITH",
+    "gender": "Male",
+    "image": "data:image/png;base64,iVBORw0KGgokJggg==",
+    "residentSince": "2015-01-01",
+    "lprCategory": "C09",
+    "lprNumber": "999-999-999",
+    "commuterClassification": "C1",
+    "birthCountry": "Bahamas",
+    "birthDate": "1958-07-17"
+  }
 }

--- a/__tests__/__fixtures__/data/test_vc_reveal_document.json
+++ b/__tests__/__fixtures__/data/test_vc_reveal_document.json
@@ -1,23 +1,24 @@
 {
-    "@context": [
-      "https://www.w3.org/2018/credentials/v1",
-      "https://w3id.org/citizenship/v1"
-    ],
-    "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
-    "type": ["VerifiableCredential", "PermanentResidentCard"],
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://w3id.org/citizenship/v1",
+    "https://w3c-ccg.github.io/ldp-bbs2020/context/v1"
+  ],
+  "id": "https://issuer.oidp.uscis.gov/credentials/83627465",
+  "type": ["VerifiableCredential", "PermanentResidentCard"],
+  "@explicit": true,
+  "issuer": "did:example:489398593",
+  "identifier": "83627465",
+  "name": "Permanent Resident Card",
+  "description": "Government of Example Permanent Resident Card.",
+  "issuanceDate": "2019-12-03T12:19:52Z",
+  "expirationDate": "2029-12-03T12:19:52Z",
+  "credentialSubject": {
+    "id": "did:example:b34ca6cd37bbf23",
+    "type": ["PermanentResident", "Person"],
     "@explicit": true,
-    "issuer": "did:example:489398593",
-    "identifier": "83627465",
-    "name": "Permanent Resident Card",
-    "description": "Government of Example Permanent Resident Card.",
-    "issuanceDate": "2019-12-03T12:19:52Z",
-    "expirationDate": "2029-12-03T12:19:52Z",
-    "credentialSubject": {
-      "id": "did:example:b34ca6cd37bbf23",
-      "type": ["PermanentResident", "Person"],
-      "@explicit": true,
-      "givenName": "JOHN",
-      "familyName": "SMITH",
-      "gender": "Male"
-    }
+    "givenName": "JOHN",
+    "familyName": "SMITH",
+    "gender": "Male"
+  }
 }

--- a/__tests__/__fixtures__/index.ts
+++ b/__tests__/__fixtures__/index.ts
@@ -14,6 +14,7 @@
 import { customLoader } from "./customDocumentLoader";
 
 import exampleBls12381KeyPair from "./data/exampleBls12381KeyPair.json";
+import exampleEd25519KeyPair from "./data/did_example_b34ca6cd37bbf23_test.json";
 import testDocument from "./data/test_document.json";
 import testRevealDocument from "./data/test_reveal_document.json";
 import testSignedDocument from "./data/test_signed_document.json";
@@ -32,6 +33,7 @@ import testRevealAllDocument from "./data/test_reveal_all_document.json";
 
 export {
   exampleBls12381KeyPair,
+  exampleEd25519KeyPair,
   testDocument,
   testRevealDocument,
   testSignedDocument,

--- a/__tests__/__fixtures__/index.ts
+++ b/__tests__/__fixtures__/index.ts
@@ -17,6 +17,9 @@ import exampleBls12381KeyPair from "./data/exampleBls12381KeyPair.json";
 import testDocument from "./data/test_document.json";
 import testRevealDocument from "./data/test_reveal_document.json";
 import testSignedDocument from "./data/test_signed_document.json";
+import testSignedDocumentMultiProofs from "./data/test_signed_document_multi_proofs.json";
+import testSignedDocumentMultiDifProofs from "./data/test_signed_document_multi_dif_proofs.json";
+import testSignedDocumentEd25519 from "./data/test_signed_document_ed25519.json";
 import testBadSignedDocument from "./data/test_bad_signed_document.json";
 import testProofDocument from "./data/test_proof_document.json";
 import testPartialProofDocument from "./data/test_partial_proof_document.json";
@@ -32,6 +35,9 @@ export {
   testDocument,
   testRevealDocument,
   testSignedDocument,
+  testSignedDocumentMultiProofs,
+  testSignedDocumentMultiDifProofs,
+  testSignedDocumentEd25519,
   testProofDocument,
   testVcDocument,
   testRevealAllDocument,

--- a/__tests__/deriveProof.spec.ts
+++ b/__tests__/deriveProof.spec.ts
@@ -23,34 +23,28 @@ import { BbsBlsSignatureProof2020, deriveProof } from "../src/index";
 
 describe("BbsBlsSignatureProof2020", () => {
   it("should derive proof", async () => {
-    jest.setTimeout(30000);
     const result = await deriveProof(testSignedDocument, testRevealDocument, {
       suite: new BbsBlsSignatureProof2020(),
-      documentLoader: customLoader,
-      compactProof: false
+      documentLoader: customLoader
     });
     expect(result).toBeDefined();
   });
 
   it("should derive proof revealing all statements", async () => {
-    jest.setTimeout(30000);
     const result = await deriveProof(testSignedDocument, testRevealDocument, {
       suite: new BbsBlsSignatureProof2020(),
-      documentLoader: customLoader,
-      compactProof: false
+      documentLoader: customLoader
     });
     expect(result).toBeDefined();
   });
 
   it("should derive proof from vc", async () => {
-    jest.setTimeout(30000);
     const result = await deriveProof(
       testSignedVcDocument,
       testRevealVcDocument,
       {
         suite: new BbsBlsSignatureProof2020(),
-        documentLoader: customLoader,
-        compactProof: false
+        documentLoader: customLoader
       }
     );
     expect(result).toBeDefined();

--- a/__tests__/getProofs.spec.ts
+++ b/__tests__/getProofs.spec.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 - MATTR Limited
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  customLoader,
+  testSignedDocumentMultiDifProofs,
+  testDocument,
+  testSignedDocumentEd25519
+} from "./__fixtures__";
+
+import { getProofs } from "../src/utilities";
+
+describe("getProofs", () => {
+  it("should get all proofs from document", async () => {
+    const result = await getProofs({
+      document: testSignedDocumentMultiDifProofs,
+      documentLoader: customLoader
+    });
+    expect(result).toBeDefined();
+    expect(result.proofs).toBeDefined();
+    expect(result.proofs.length).toEqual(2);
+    expect(result.document).toBeDefined();
+  });
+
+  it("should get proofs from document filtered by type", async () => {
+    const result = await getProofs({
+      document: testSignedDocumentMultiDifProofs,
+      proofType:
+        "https://w3c-ccg.github.io/ldp-bbs2020/context/v1#BbsBlsSignature2020",
+      documentLoader: customLoader
+    });
+    expect(result).toBeDefined();
+    expect(result.proofs).toBeDefined();
+    expect(result.proofs.length).toEqual(1);
+    expect(result.document).toBeDefined();
+  });
+
+  it("should return empty proof array when no proofs found", async () => {
+    const result = await getProofs({
+      document: testDocument,
+      documentLoader: customLoader
+    });
+    expect(result).toBeDefined();
+    expect(result.proofs).toBeDefined();
+    expect(result.proofs.length).toEqual(0);
+    expect(result.document).toBeDefined();
+  });
+
+  it("should return empty proof array when no proofs found for type", async () => {
+    const result = await getProofs({
+      document: testSignedDocumentEd25519,
+      proofType:
+        "https://w3c-ccg.github.io/ldp-bbs2020/context/v1#BbsBlsSignature2020",
+      documentLoader: customLoader
+    });
+    expect(result).toBeDefined();
+    expect(result.proofs).toBeDefined();
+    expect(result.proofs.length).toEqual(0);
+    expect(result.document).toBeDefined();
+  });
+});

--- a/__tests__/index.d.ts
+++ b/__tests__/index.d.ts
@@ -1,0 +1,2 @@
+declare module "vc-js";
+declare module "crypto-ld";

--- a/__tests__/vc-js.spec.ts
+++ b/__tests__/vc-js.spec.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2020 - MATTR Limited
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  customLoader,
+  testVcDocument,
+  testSignedVcDocument,
+  exampleBls12381KeyPair,
+  exampleEd25519KeyPair,
+  testRevealVcDocument
+} from "./__fixtures__";
+
+import vc from "vc-js";
+import { Ed25519KeyPair } from "crypto-ld";
+import jsigs from "jsonld-signatures";
+import {
+  BbsBlsSignature2020,
+  Bls12381G2KeyPair,
+  deriveProof,
+  BbsBlsSignatureProof2020
+} from "../src";
+
+const key = new Bls12381G2KeyPair(exampleBls12381KeyPair);
+const ed25519Key = new Ed25519KeyPair(exampleEd25519KeyPair);
+
+/**
+ * Tests integration with vc-js
+ * @see https://github.com/digitalbazaar/vc-js
+ */
+describe("vc-js integration", () => {
+  it("should issue verifiable credential", async () => {
+    const verifiableCredential = await vc.issue({
+      credential: testVcDocument,
+      documentLoader: customLoader,
+      suite: new BbsBlsSignature2020({ key })
+    });
+
+    expect(verifiableCredential.proof).toBeDefined();
+  });
+
+  it("should verify verifiable credential", async () => {
+    const result = await vc.verifyCredential({
+      credential: testSignedVcDocument,
+      documentLoader: customLoader,
+      suite: new BbsBlsSignature2020()
+    });
+
+    expect(result.verified).toBe(true);
+  });
+
+  it("should derive and verify proof", async () => {
+    const derivedProof = await deriveProof(
+      testSignedVcDocument,
+      testRevealVcDocument,
+      {
+        suite: new BbsBlsSignatureProof2020(),
+        documentLoader: customLoader
+      }
+    );
+
+    const result = await vc.verifyCredential({
+      credential: derivedProof,
+      documentLoader: customLoader,
+      suite: new BbsBlsSignatureProof2020()
+    });
+
+    expect(result.verified).toBe(true);
+  });
+
+  it("should derive proof, create & sign presentation", async () => {
+    const holder = "did:example:b34ca6cd37bbf23";
+    const derivedProof = await deriveProof(
+      testSignedVcDocument,
+      testRevealVcDocument,
+      {
+        suite: new BbsBlsSignatureProof2020(),
+        documentLoader: customLoader
+      }
+    );
+
+    const presentation = vc.createPresentation({
+      verifiableCredential: derivedProof,
+      holder
+    });
+
+    const verifiablePresentation = await vc.signPresentation({
+      presentation,
+      suite: new jsigs.suites.Ed25519Signature2018({ key: ed25519Key }),
+      challenge: "123",
+      documentLoader: customLoader
+    });
+
+    expect(verifiablePresentation.proof).toBeDefined();
+  });
+
+  it("should derive proof, create, sign and verify presentation", async () => {
+    const holder = "did:example:b34ca6cd37bbf23";
+    const id = "urn:uuid:1234";
+    const derivedProof = await deriveProof(
+      testSignedVcDocument,
+      testRevealVcDocument,
+      {
+        suite: new BbsBlsSignatureProof2020(),
+        documentLoader: customLoader
+      }
+    );
+
+    const presentation = vc.createPresentation({
+      verifiableCredential: derivedProof,
+      holder,
+      id
+    });
+
+    const verifiablePresentation = await vc.signPresentation({
+      presentation,
+      suite: new jsigs.suites.Ed25519Signature2018({ key: ed25519Key }),
+      challenge: "123",
+      documentLoader: customLoader
+    });
+
+    const result = await vc.verify({
+      presentation: verifiablePresentation,
+      suite: [
+        new jsigs.suites.Ed25519Signature2018(),
+        new BbsBlsSignatureProof2020()
+      ],
+      challenge: "123",
+      documentLoader: customLoader
+    });
+
+    expect(result.verified).toBe(true);
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,7 +7,8 @@ module.exports = {
   testRegex: [".spec.ts$"],
   moduleFileExtensions: ["ts", "tsx", "js", "jsx", "json", "node"],
   coveragePathIgnorePatterns: ["<rootDir>/__tests__"],
+  testTimeout: 10000,
   verbose: true,
   name: pack.name,
-  displayName: pack.name,
+  displayName: pack.name
 };

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@typescript-eslint/parser": "2.28.0",
     "conventional-changelog": "3.1.18",
     "conventional-changelog-cli": "2.0.31",
+    "crypto-ld": "3.8.0",
     "cz-conventional-changelog": "3.1.0",
     "eslint": "6.8.0",
     "eslint-config-prettier": "^6.10.1",
@@ -62,7 +63,8 @@
     "pretty-quick": "2.0.1",
     "ts-jest": "25.4.0",
     "ts-node": "8.4.1",
-    "typescript": "3.7.5"
+    "typescript": "3.7.5",
+    "vc-js": "0.6.4"
   },
   "dependencies": {
     "@mattrglobal/bls12381-key-pair": "0.3.0",

--- a/src/BbsBlsSignature2020.ts
+++ b/src/BbsBlsSignature2020.ts
@@ -23,7 +23,7 @@ import {
   VerifySignatureOptions,
   SuiteSignOptions
 } from "./types";
-import { w3cDate } from "./w3cDate";
+import { w3cDate } from "./utilities";
 import { Bls12381G2KeyPair } from "@mattrglobal/bls12381-key-pair";
 
 /**
@@ -49,12 +49,20 @@ export class BbsBlsSignature2020 extends suites.LinkedDataProof {
     ) {
       throw new TypeError('"verificationMethod" must be a URL string.');
     }
-    super({ type: "BbsBlsSignature2020" });
+    super({
+      type:
+        "https://w3c-ccg.github.io/ldp-bbs2020/context/v1#BbsBlsSignature2020"
+    });
+
+    this.proof = {
+      "@context": "https://w3c-ccg.github.io/ldp-bbs2020/context/v1",
+      type: "BbsBlsSignature2020"
+    };
 
     this.LDKeyClass = Bls12381G2KeyPair;
     this.signer = signer;
     this.verificationMethod = verificationMethod;
-    this.proofSignatureKey = "signature";
+    this.proofSignatureKey = "proofValue";
     if (key) {
       if (verificationMethod === undefined) {
         this.verificationMethod = key.id;
@@ -229,7 +237,7 @@ export class BbsBlsSignature2020 extends suites.LinkedDataProof {
   async canonizeProof(proof: any, options: CanonizeOptions): Promise<string> {
     const { documentLoader, expansionMap } = options;
     proof = { ...proof };
-    delete proof.signature;
+    delete proof[this.proofSignatureKey];
     return this.canonize(proof, {
       documentLoader,
       expansionMap,

--- a/src/BbsBlsSignatureProof2020.ts
+++ b/src/BbsBlsSignatureProof2020.ts
@@ -31,9 +31,19 @@ import { Bls12381G2KeyPair } from "@mattrglobal/bls12381-key-pair";
 
 export class BbsBlsSignatureProof2020 extends suites.LinkedDataProof {
   constructor({ useNativeCanonize, key }: any = {}) {
-    super({ type: "BbsBlsSignatureProof2020" });
+    super({
+      type:
+        "https://w3c-ccg.github.io/ldp-bbs2020/context/v1#BbsBlsSignatureProof2020"
+    });
+
+    this.proof = {
+      "@context": "https://w3c-ccg.github.io/ldp-bbs2020/context/v1",
+      type: "BbsBlsSignatureProof2020"
+    };
+    this.supportedDeriveProofType =
+      "https://w3c-ccg.github.io/ldp-bbs2020/context/v1#BbsBlsSignature2020";
     this.LDKeyClass = Bls12381G2KeyPair;
-    this.proofSignatureKey = "signature";
+    this.proofSignatureKey = "proofValue";
     this.key = key;
     this.useNativeCanonize = useNativeCanonize;
   }
@@ -52,35 +62,52 @@ export class BbsBlsSignatureProof2020 extends suites.LinkedDataProof {
       revealDocument,
       documentLoader,
       expansionMap,
-      compactProof
+      skipProofCompaction
     } = options;
     let { nonce } = options;
 
-    // Validate that the input proof document has a proof compatible with the suite
-    if (proof.type !== "BbsBlsSignature2020") {
+    // Validate that the input proof document has a proof compatible with this suite
+    if (proof.type !== this.supportedDeriveProofType) {
       throw new TypeError(
-        "proof document proof incompatible, expected proof type of BbsBlsSignature2020"
+        `proof document proof incompatible, expected proof type of ${this.supportedDeriveProofType} received ${proof.type}`
       );
     }
 
     //Extract the BBS signature from the input proof
-    const signature = Buffer.from(proof.signature, "base64");
+    const signature = Buffer.from(proof[this.proofSignatureKey], "base64");
 
     //Initialize the BBS signature suite
     const suite = new BbsBlsSignature2020();
+
+    //Initialize the derived proof
+    let derivedProof;
+    if (this.proof) {
+      // use proof JSON-LD document passed to API
+      derivedProof = await jsonld.compact(this.proof, SECURITY_CONTEXT_URL, {
+        documentLoader,
+        expansionMap,
+        compactToRelative: false
+      });
+    } else {
+      // create proof JSON-LD document
+      derivedProof = { "@context": SECURITY_CONTEXT_URL };
+    }
+
+    // ensure proof type is set
+    derivedProof.type = this.type;
 
     // Get the input document statements
     const documentStatements = await suite.createVerifyDocumentData(document, {
       documentLoader,
       expansionMap,
-      compactProof
+      compactProof: !skipProofCompaction
     });
 
     // Get the proof statements
     const proofStatements = await suite.createVerifyProofData(proof, {
       documentLoader,
       expansionMap,
-      compactProof
+      compactProof: !skipProofCompaction
     });
 
     // Transform any blank node identifiers for the input
@@ -144,12 +171,16 @@ export class BbsBlsSignatureProof2020 extends suites.LinkedDataProof {
       );
     }
 
+    // Combine all indicies to get the resulting list of revealed indicies
     const revealIndicies = proofRevealIndicies.concat(documentRevealIndicies);
 
     // Create a nonce if one is not supplied
     if (!nonce) {
       nonce = Buffer.from(randomBytes(50)).toString("base64");
     }
+
+    // Set the nonce on the derived proof
+    derivedProof.nonce = nonce;
 
     //Combine all the input statements that
     //were originally signed to generate the proof
@@ -163,8 +194,10 @@ export class BbsBlsSignatureProof2020 extends suites.LinkedDataProof {
       expansionMap
     });
 
+    // Construct a key pair class from the returned verification method
     const key = await this.LDKeyClass.from(verificationMethod);
 
+    // Compute the proof
     const outputProof = blsCreateProof({
       signature: new Uint8Array(signature),
       publicKey: new Uint8Array(key.publicKeyBuffer),
@@ -173,19 +206,17 @@ export class BbsBlsSignatureProof2020 extends suites.LinkedDataProof {
       revealed: revealIndicies
     });
 
-    const inputProof = { ...proof };
+    // Set the proof value on the derived proof
+    derivedProof.proofValue = Buffer.from(outputProof).toString("base64");
 
-    delete inputProof.signature;
-    delete inputProof.type;
+    // Set the relevant proof elements on the derived proof from the input proof
+    derivedProof.verificationMethod = proof.verificationMethod;
+    derivedProof.proofPurpose = proof.proofPurpose;
+    derivedProof.created = proof.created;
 
     return {
-      ...revealDocumentResult,
-      proof: {
-        type: this.type,
-        ...inputProof,
-        proofValue: Buffer.from(outputProof).toString("base64"),
-        nonce
-      }
+      document: { ...revealDocumentResult },
+      proof: derivedProof
     };
   }
 
@@ -195,9 +226,12 @@ export class BbsBlsSignatureProof2020 extends suites.LinkedDataProof {
    * @returns {Promise<{object}>} Resolves with the verification result.
    */
   async verifyProof(options: VerifyProofOptions): Promise<VerifyProofResult> {
-    const { proof, document, documentLoader, expansionMap, purpose } = options;
+    const { document, documentLoader, expansionMap, purpose } = options;
+    const { proof } = options;
 
     try {
+      proof.type = this.supportedDeriveProofType;
+
       // Get the proof statements
       const proofStatements = await this.createVerifyProofData(proof, {
         documentLoader,
@@ -283,8 +317,6 @@ export class BbsBlsSignatureProof2020 extends suites.LinkedDataProof {
     const { documentLoader, expansionMap } = options;
     proof = { ...proof };
 
-    delete proof.totalStatements;
-    delete proof.revealStatements;
     delete proof.nonce;
     delete proof.proofValue;
 

--- a/src/deriveProof.ts
+++ b/src/deriveProof.ts
@@ -50,6 +50,7 @@ export const deriveProof = async (
   });
 
   if (!skipProofCompaction) {
+    /* eslint-disable prefer-const */
     let expandedProof: any = {
       [SECURITY_PROOF_URL]: { "@graph": result.proof }
     };

--- a/src/types/GetProofsOptions.ts
+++ b/src/types/GetProofsOptions.ts
@@ -13,21 +13,17 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
- * Options for creating a proof
+ * Options for getting a proof from a JSON-LD document
  */
-export interface DeriveProofOptions {
+export interface GetProofsOptions {
   /**
-   * Document outlining what statements to reveal
-   */
-  readonly revealDocument: any;
-  /**
-   * The document featuring the proof to derive from
+   * The JSON-LD document to extract the proofs from.
    */
   readonly document: any;
   /**
-   * The proof for the document
+   * Optional the proof type to filter the returned proofs by
    */
-  readonly proof: any;
+  readonly proofType?: string;
   /**
    * Optional custom document loader
    */
@@ -37,11 +33,7 @@ export interface DeriveProofOptions {
    */
   expansionMap?(): any;
   /**
-   * Nonce to include in the derived proof
-   */
-  readonly nonce?: string;
-  /**
-   * Indicates whether to compact the resulting proof
+   * Optional property to indicate whether to skip compacting the resulting proof
    */
   readonly skipProofCompaction?: boolean;
 }

--- a/src/types/GetProofsResult.ts
+++ b/src/types/GetProofsResult.ts
@@ -13,35 +13,15 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /**
- * Options for creating a proof
+ * Result for getting proofs from a JSON-LD document
  */
-export interface DeriveProofOptions {
+export interface GetProofsResult {
   /**
-   * Document outlining what statements to reveal
+   * The JSON-LD document with the linked data proofs removed.
    */
-  readonly revealDocument: any;
+  document: any;
   /**
-   * The document featuring the proof to derive from
+   * The list of proofs that matched the requested type.
    */
-  readonly document: any;
-  /**
-   * The proof for the document
-   */
-  readonly proof: any;
-  /**
-   * Optional custom document loader
-   */
-  documentLoader?(): any;
-  /**
-   * Optional expansion map
-   */
-  expansionMap?(): any;
-  /**
-   * Nonce to include in the derived proof
-   */
-  readonly nonce?: string;
-  /**
-   * Indicates whether to compact the resulting proof
-   */
-  readonly skipProofCompaction?: boolean;
+  proofs: any;
 }

--- a/src/types/GetTypeOptions.ts
+++ b/src/types/GetTypeOptions.ts
@@ -11,15 +11,17 @@
  * limitations under the License.
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 /**
- * Formats an input date to w3c standard date format
- * @param date {number|string} Optional if not defined current date is returned
+ * Options for getting the type from a JSON-LD document
  */
-export const w3cDate = (date?: number | string): string => {
-  let result = new Date();
-  if (typeof date === "number" || typeof date === "string") {
-    result = new Date(date);
-  }
-  const str = result.toISOString();
-  return str.substr(0, str.length - 5) + "Z";
-};
+export interface GetTypeOptions {
+  /**
+   * Optional custom document loader
+   */
+  documentLoader?(): any;
+  /**
+   * Optional expansion map
+   */
+  expansionMap?(): any;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,3 +22,6 @@ export { CreateVerifyDataOptions } from "./CreateVerifyDataOptions";
 export { VerifySignatureOptions } from "./VerifySignatureOptions";
 export { SuiteSignOptions } from "./SuiteSignOptions";
 export { DeriveProofOptions } from "./DeriveProofOptions";
+export { GetProofsOptions } from "./GetProofsOptions";
+export { GetProofsResult } from "./GetProofsResult";
+export { GetTypeOptions } from "./GetTypeOptions";

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,0 +1,118 @@
+/*
+ * The code in this file originated from
+ * @see https://github.com/digitalbazaar/jsonld-signatures
+ * Hence the following copyright notice applies
+ *
+ * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { SECURITY_CONTEXT_URL } from "jsonld-signatures";
+import jsonld from "jsonld";
+import { GetProofsOptions, GetProofsResult, GetTypeOptions } from "./types";
+
+/**
+ * The property identifying the linked data proof
+ * Note - this will not work for legacy systems that
+ * relying on `signature`
+ */
+const PROOF_PROPERTY = "proof";
+
+/**
+ * Gets a supported linked data proof from a JSON-LD Document
+ * Note - unless instructed not to the document will be compacted
+ * against the security v2 context @see https://w3id.org/security/v2
+ *
+ * @param options Options for extracting the proof from the document
+ *
+ * @returns {GetProofsResult} An object containing the matched proofs and the JSON-LD document
+ */
+export const getProofs = async (
+  options: GetProofsOptions
+): Promise<GetProofsResult> => {
+  const {
+    proofType,
+    skipProofCompaction,
+    documentLoader,
+    expansionMap
+  } = options;
+  let { document } = options;
+
+  let proofs;
+  if (!skipProofCompaction) {
+    // If we must compact the proof then we must first compact the input
+    // document to find the proof
+    document = await jsonld.compact(document, SECURITY_CONTEXT_URL, {
+      documentLoader,
+      expansionMap,
+      compactToRelative: false
+    });
+  }
+
+  proofs = jsonld.getValues(document, PROOF_PROPERTY);
+  delete document[PROOF_PROPERTY];
+
+  if (proofType) {
+    proofs = proofs.filter((_: any) => _.type == proofType);
+  }
+
+  proofs = proofs.map((matchedProof: any) => ({
+    "@context": SECURITY_CONTEXT_URL,
+    ...matchedProof
+  }));
+
+  return {
+    proofs,
+    document
+  };
+};
+
+/**
+ * Formats an input date to w3c standard date format
+ * @param date {number|string} Optional if not defined current date is returned
+ *
+ * @returns {string} date in a standard format as a string
+ */
+export const w3cDate = (date?: number | string): string => {
+  let result = new Date();
+  if (typeof date === "number" || typeof date === "string") {
+    result = new Date(date);
+  }
+  const str = result.toISOString();
+  return str.substr(0, str.length - 5) + "Z";
+};
+
+/**
+ * Gets the JSON-LD type information for a document
+ * @param document {any} JSON-LD document to extract the type information from
+ * @param options {GetTypeInfoOptions} Options for extracting the JSON-LD document
+ *
+ * @returns {string} date in a standard format as a string
+ */
+export const getTypeInfo = async (document: any, options: GetTypeOptions) => {
+  const { documentLoader, expansionMap } = options;
+
+  // determine `@type` alias, if any
+  const context = jsonld.getValues(document, "@context");
+
+  const compacted = await jsonld.compact({ "@type": "_:b0" }, context, {
+    documentLoader,
+    expansionMap
+  });
+
+  delete compacted["@context"];
+
+  const alias = Object.keys(compacted)[0];
+
+  // optimize: expand only `@type` and `type` values
+  let toExpand: any = { "@context": context };
+  toExpand["@type"] = jsonld
+    .getValues(document, "@type")
+    .concat(jsonld.getValues(document, alias));
+
+  const expanded =
+    (await jsonld.expand(toExpand, { documentLoader, expansionMap }))[0] || {};
+
+  return { types: jsonld.getValues(expanded, "@type"), alias };
+};

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -88,9 +88,12 @@ export const w3cDate = (date?: number | string): string => {
  * @param document {any} JSON-LD document to extract the type information from
  * @param options {GetTypeInfoOptions} Options for extracting the JSON-LD document
  *
- * @returns {string} date in a standard format as a string
+ * @returns {object} Type info for the JSON-LD document
  */
-export const getTypeInfo = async (document: any, options: GetTypeOptions) => {
+export const getTypeInfo = async (
+  document: any,
+  options: GetTypeOptions
+): Promise<any> => {
   const { documentLoader, expansionMap } = options;
 
   // determine `@type` alias, if any
@@ -106,6 +109,7 @@ export const getTypeInfo = async (document: any, options: GetTypeOptions) => {
   const alias = Object.keys(compacted)[0];
 
   // optimize: expand only `@type` and `type` values
+  /* eslint-disable prefer-const */
   let toExpand: any = { "@context": context };
   toExpand["@type"] = jsonld
     .getValues(document, "@type")

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,18 @@
 {
-    "compilerOptions": {
-        "module": "commonjs",
-        "target": "es2017",
-        "sourceMap": true,
-        "allowJs": false,
-        "moduleResolution": "node",
-        "strict": true,
-        "declaration": true,
-        "downlevelIteration": true,
-        "baseUrl": ".",
-        "esModuleInterop": true,
-        "resolveJsonModule": true,
-        "outDir": "./lib",
-        "types": [
-            "jest",
-            "node"
-          ]
-    },
-    "include": ["./src"]
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "sourceMap": true,
+    "allowJs": false,
+    "moduleResolution": "node",
+    "strict": true,
+    "declaration": true,
+    "downlevelIteration": true,
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "outDir": "./lib",
+    "types": ["jest", "node"]
+  },
+  "include": ["./src", "./__tests__"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1552,7 +1552,7 @@ command-line-usage@^4.0.0:
     table-layout "^0.4.2"
     typical "^2.6.1"
 
-commander@~2.20.3:
+commander@^2.20.3, commander@~2.20.3:
   version "2.20.3"
   resolved "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
@@ -1833,6 +1833,11 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
+credentials-context@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/credentials-context/-/credentials-context-1.0.0.tgz#a63cb4b7e0a4ca4460d247b7c9370a58b10ebac9"
+  integrity sha512-rF3GPhTUGY58xlpuVRif/1i0BxVpynpmFdGNS81S2ezdKPSKoFke5ZOZWB8ZUvGi8bV8CuDM+ZcM/uf4z0PQVQ==
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -1852,6 +1857,18 @@ cross-spawn@^7.0.0:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
     which "^2.0.1"
+
+crypto-ld@3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/crypto-ld/-/crypto-ld-3.8.0.tgz#0a4bd269e5631f88db18df32aa85531eada3c510"
+  integrity sha512-NOKR2Ohoxc+1AnkLQUV0bSNRRzTdAeH6zMMakiqE7b22wHokQs65scLn58O4jD81V0mQQr27ytkmm1QgH3kT7w==
+  dependencies:
+    base64url-universal "^1.0.1"
+    bs58 "^4.0.1"
+    node-forge "~0.9.0"
+    semver "^6.2.0"
+  optionalDependencies:
+    sodium-native "^3.2.0"
 
 crypto-ld@^3.7.0:
   version "3.7.0"
@@ -2631,7 +2648,7 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-fs-extra@8.1.0:
+fs-extra@8.1.0, fs-extra@^8.1.0:
   version "8.1.0"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -2702,7 +2719,7 @@ get-pkg-repo@^1.0.0:
     parse-github-repo-url "^1.3.0"
     through2 "^2.0.0"
 
-get-stdin@7.0.0:
+get-stdin@7.0.0, get-stdin@^7.0.0:
   version "7.0.0"
   resolved "https://registry.npmjs.org/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
   integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
@@ -3930,6 +3947,18 @@ jsonld-signatures@5.0.1:
     security-context "^4.0.0"
     serialize-error "^5.0.0"
 
+jsonld-signatures@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/jsonld-signatures/-/jsonld-signatures-5.1.0.tgz#b64c59ba0b190deaf14522155a5a2d3fd12ff111"
+  integrity sha512-cI/iZbbU0ndH74L1AmSziSh59QxigPQLVbC7Xdy0TCxzisBfXScB/TjGOR6r/qZ0cFeXldBKiCHaDjB8825WPw==
+  dependencies:
+    base64url "^3.0.1"
+    crypto-ld "^3.7.0"
+    jsonld "^2.0.2"
+    node-forge "^0.9.1"
+    security-context "^4.0.0"
+    serialize-error "^5.0.0"
+
 jsonld@3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/jsonld/-/jsonld-3.1.0.tgz#826a7a598942a3969d41301388c51b812a73c6d0"
@@ -4449,6 +4478,11 @@ node-gyp-build@^4.1.0:
   version "4.2.2"
   resolved "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz#3f44b65adaafd42fb6c3d81afd630e45c847eb66"
   integrity sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==
+
+node-gyp-build@^4.2.0:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.2.3.tgz#ce6277f853835f718829efb47db20f3e4d9c4739"
+  integrity sha512-MN6ZpzmfNCRM+3t57PTJHgHyw/h4OWnZ6mR8P5j/uZtqQr46RRuDE/P+g3n0YR/AiYXeWixZZzaip77gdICfRg==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -5591,6 +5625,14 @@ sodium-native@^2.3.0:
     nan "^2.14.0"
     node-gyp-build "^4.1.0"
 
+sodium-native@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/sodium-native/-/sodium-native-3.2.0.tgz#68a9469b96edadffef320cbce51294ad5f72a37f"
+  integrity sha512-8aq/vQSegLwsRch8Sb/Bpf9aAqlNe5dp0+NVhb9UjHv42zDZ0D5zX3wBRUbXK9Ejum9uZE6DUgT4vVLlUFRBWg==
+  dependencies:
+    ini "^1.3.5"
+    node-gyp-build "^4.2.0"
+
 source-map-resolve@^0.5.0:
   version "0.5.3"
   resolved "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz#190866bece7553e1f8f267a2ee82c606b5509a1a"
@@ -6310,6 +6352,20 @@ validate-npm-package-name@^3.0.0:
   integrity sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
   dependencies:
     builtins "^1.0.3"
+
+vc-js@0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/vc-js/-/vc-js-0.6.4.tgz#49f408c590260d28c25a3ca4e30ece0de61c3ae1"
+  integrity sha512-ogwYys94k8mFyFZEn1Ru3nIA5Z/9C4iCU4grNWUYOYVWldcsn6UDp6erYFbaSkilzv7RK3cQu5N8prkxfHpZwA==
+  dependencies:
+    commander "^2.20.3"
+    credentials-context "^1.0.0"
+    debug "^4.1.1"
+    fs-extra "^8.1.0"
+    get-stdin "^7.0.0"
+    jsonld "^2.0.2"
+    jsonld-signatures "^5.0.0"
+    supports-color "^7.1.0"
 
 verror@1.10.0:
   version "1.10.0"


### PR DESCRIPTION
## Description

The primary purpose of this PR is to resolve an issue around compacting the JSON-LD context for this signature suite against the security context v2 correctly. This was leading to incorrect behaviour when the signature suite was being used in upstream libraries like vc-js.

The top level api for the suites in the library have also been simplified, removing the need to supply `compactProof` and `expansionMap`.

The `BbsBlsSignature2020` now uses the proofValue field instead of signature for proofs.

Some common utility functions have been extracted out and have their own test coverage.

The return of `deriveProof` for the BbsBlsSignatureProof2020 returns the derived document and the derived proof separately now requiring the caller to combine the result, more inline with how jsonld-signatures `createProof` works.

Multiple remote contexts have now been cached in the customer document loader for test execution performance.

Integration test coverage with vc-js has also been added.

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

Completed integration with jsonld-signatures and vc-js

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

See explanation above

## Which merge strategy will you use?

- [ ] Squash
- [x] Rebase (REVIEW COMMITS)
