### PR TITLE
ci(github-actions): update secret management

### DIFF
--- a/.github/workflows/any-pr.yaml
+++ b/.github/workflows/any-pr.yaml
@@ -14,10 +14,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: "https://registry.npmjs.org"
       - run: yarn install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLIC_TOKEN }}
       - run: yarn lint
       - run: yarn build
       - run: yarn test --coverage

--- a/.github/workflows/any-pr.yaml
+++ b/.github/workflows/any-pr.yaml
@@ -17,7 +17,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: yarn install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLIC_TOKEN }}
       - run: yarn lint
       - run: yarn build
       - run: yarn test --coverage

--- a/.github/workflows/push-master.yaml
+++ b/.github/workflows/push-master.yaml
@@ -19,10 +19,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: "https://registry.npmjs.org"
       - run: yarn install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLIC_TOKEN }}
       - run: yarn lint
       - run: yarn build
       - run: yarn test --coverage

--- a/.github/workflows/push-master.yaml
+++ b/.github/workflows/push-master.yaml
@@ -22,13 +22,13 @@ jobs:
           registry-url: "https://registry.npmjs.org"
       - run: yarn install --frozen-lockfile
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLIC_TOKEN }}
       - run: yarn lint
       - run: yarn build
       - run: yarn test --coverage
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc 2> /dev/null
         env:
-          NPM_TOKEN: ${{ secrets.NPMJS_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPMJS_PUBLIC_TOKEN }}
       - run: git config user.name "Mattr CI"
       - run: git config user.email "npmjs_ci_mattr_public@mattr.global"
       - run: npm whoami

--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -11,27 +11,27 @@ jobs:
     if: "contains(github.event.head_commit.message, 'chore(release): publish')"
     runs-on: ubuntu-latest
     strategy:
-        matrix:
-          node-version: [10.x]
+      matrix:
+        node-version: [10.x]
     steps:
-        - uses: actions/checkout@v2
-        - name: Use Node.js ${{ matrix.node-version }}
-          uses: actions/setup-node@v1
-          with:
-            node-version: ${{ matrix.node-version }}
-            registry-url: "https://registry.npmjs.org"
-        - run: yarn install --frozen-lockfile
-          env:
-            NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}
-        - run: yarn lint
-        - run: yarn build
-        - run: yarn test
-        - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc 2> /dev/null
-          env:
-            NPM_TOKEN: ${{ secrets.NPMJS_TOKEN }}
-        - run: git config user.name "Mattr CI"
-        - run: git config user.email "npmjs_ci_mattr_public@mattr.global"
-        - run: npm whoami
-        - run: yarn publish:release
-          env:
-            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: "https://registry.npmjs.org"
+      - run: yarn install --frozen-lockfile
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLIC_TOKEN }}
+      - run: yarn lint
+      - run: yarn build
+      - run: yarn test
+      - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > .npmrc 2> /dev/null
+        env:
+          NPM_TOKEN: ${{ secrets.NPMJS_PUBLIC_TOKEN }}
+      - run: git config user.name "Mattr CI"
+      - run: git config user.email "npmjs_ci_mattr_public@mattr.global"
+      - run: npm whoami
+      - run: yarn publish:release
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLIC_TOKEN }}

--- a/.github/workflows/push-release.yaml
+++ b/.github/workflows/push-release.yaml
@@ -19,10 +19,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node-version }}
-          registry-url: "https://registry.npmjs.org"
       - run: yarn install --frozen-lockfile
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLIC_TOKEN }}
       - run: yarn lint
       - run: yarn build
       - run: yarn test
@@ -33,5 +30,3 @@ jobs:
       - run: git config user.email "npmjs_ci_mattr_public@mattr.global"
       - run: npm whoami
       - run: yarn publish:release
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_PUBLIC_TOKEN }}


### PR DESCRIPTION
## Description

Renames the name of the secret representing the npmjs token required to authenticate with the package registry for publishing of the npm package, removes unnecessary uses of the token.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

CI maintenance

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
