### PR TITLE
feat: use local context instead of security v3

### DIFF
--- a/src/BbsBlsSignature2020.ts
+++ b/src/BbsBlsSignature2020.ts
@@ -55,7 +55,17 @@ export class BbsBlsSignature2020 extends suites.LinkedDataProof {
     });
 
     this.proof = {
-      "@context": "https://w3id.org/security/v3-unstable",
+      "@context": [
+        {
+          sec: "https://w3id.org/security#",
+          proof: {
+            "@id": "sec:proof",
+            "@type": "@id",
+            "@container": "@graph"
+          }
+        },
+        "https://w3id.org/security/bbs/v1"
+      ],
       type: "BbsBlsSignature2020"
     };
 

--- a/src/BbsBlsSignatureProof2020.ts
+++ b/src/BbsBlsSignatureProof2020.ts
@@ -33,7 +33,17 @@ export class BbsBlsSignatureProof2020 extends suites.LinkedDataProof {
     });
 
     this.proof = {
-      "@context": "https://w3id.org/security/v3-unstable",
+      "@context": [
+        {
+          sec: "https://w3id.org/security#",
+          proof: {
+            "@id": "sec:proof",
+            "@type": "@id",
+            "@container": "@graph"
+          }
+        },
+        "https://w3id.org/security/bbs/v1"
+      ],
       type: "BbsBlsSignatureProof2020"
     };
     this.mappedDerivedProofType =


### PR DESCRIPTION
## Description

As highlighted in #111 v0.8.0 introduced a dependency on the unstable security v3 context which adds undesirable complication on the document loader for this library when only one term is used. This PR shifts to a local definition of the proof term so loading v3 is no-longer required.

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

See above

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
