### PR TITLE
test: use valid vc documents for vc tests

### DIFF
--- a/__tests__/__fixtures__/data/test_nested_reveal_document.json
+++ b/__tests__/__fixtures__/data/test_nested_reveal_document.json
@@ -6,6 +6,8 @@
   ],
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
   "@explicit": true,
+  "issuer": {},
+  "issuanceDate": {},
   "credentialSubject": {
     "@explicit": true,
     "degree": {

--- a/__tests__/__fixtures__/data/test_nested_vc_document.json
+++ b/__tests__/__fixtures__/data/test_nested_vc_document.json
@@ -6,6 +6,7 @@
   ],
   "id": "https://example.gov/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": "did:example:489398593",
   "issuanceDate": "2020-03-10T04:24:12.164Z",
   "credentialSubject": {
     "id": "did:example:489398593",

--- a/__tests__/__fixtures__/data/test_partial_proof_nested_vc_document.json
+++ b/__tests__/__fixtures__/data/test_partial_proof_nested_vc_document.json
@@ -14,12 +14,14 @@
       "name": "Bachelor of Science and Arts"
     }
   },
+  "issuanceDate": "2020-03-10T04:24:12.164Z",
+  "issuer": "did:example:489398593",
   "proof": {
     "type": "BbsBlsSignatureProof2020",
-    "created": "2020-12-14T03:11:30Z",
-    "nonce": "am6ZmHvRRrhDNdiEzfpZm7kBLwlh5B4ULmwczzH9iwtLnMu7QhH9WaWmtEwJ0LrwdpI=",
+    "created": "2021-04-26T17:55:05Z",
+    "nonce": "58pQbOsBR7l+FwAGs1bDWiCyQXJFkmSNBHC0BDzX4BU6khM6VbJZBqb5RGONkGFJBNQ=",
     "proofPurpose": "assertionMethod",
-    "proofValue": "AA0N76Kuc+1HYPajNPxCemRdLGV0q5nUIB0DdOm1nsrbql6JsyM5TzTSBIcG7u6plxPLI7VCrxYQ16u2CjlafhlXXLBvm+ERVPN2i2aPgq+h9Ykb3sVGYEwI34nLDeeMAyo9gbLJoKnFBggaBe0h5uyJLQVefuegsdhAe6/tishSBp8/um9odS+3vMVh9EwNvfVpbAAAAHSHEWi10j8BRaTgvn3KX5R6xS9AdzbHlHt5z3ZcBRnJi9jB1l2BJHR/KypsNT7EJjcAAAACanX0ZNVF4p/SlCS9SY8bGWL4SyEMWfpvacZ/bR8pZG9PVMDZUEPsN1QpjQnekkIWks3ep42r8veuoDwlzQljMLnxGFQ78hwVpzWnAwpur2kR41Gbhq/r2XXwYY3U/tN2VBHHXMOj11YJARAbT4VUmAAAAAUBFdHA3fGTapyNQUZbvwTlWYSTX1ABL1hSTvd5O+a1QHJymaIoOVevNWQCVq+TIlGvcBiJmF0TVFV1DjDgFMFhVRLmw6zEYEMQZkaOv8eRlDbAVZGPtJpZr8GLN6wlfE1GhPwi8iLzYR01Y8sV6dqLtJvSHf8gnqieBJUTT4M9rkgOn/5zM6q4Su6bDUfgMWqlH75tPzxVwMG9Gbw4J+Vt",
+    "proofValue": "AA4f74GNgyGujm0aHzKd2xuUpetxhpFaXhW6twInMfmFNZYW2/RlShvRGE6Ios/dgr5e+qyGGOGkBWSdSOaFGsseo6Ne/0429iKAZpWo/abD6r8kIszn8L5UL43NxCia/UtQB5HjqBPYelAsepN3aNryZNUc0h7UcyjTqgp9wGfPADW4KJIBXv4SvwqwRZgcDzdKxwAAAHSStf9LAUTsKXnlWL7hE0x86/4wzpDFRWCE/WgkCz/mqQlt+vlWDwm9k7PlwiPoLhYAAAACBLS2axWssG0oNnqk02If5qm6ToalAP/TGB/cORH00KNrKMvhMMwI54odGP5qy4qJmQp+cYcj4bffIfaXbRGNqJdHYKbeHk5ZV/A91vnI3mxQfhtKp1YmNC2DpUfw/hSTAubh5Iv2UMFWc1Gl+hYuDAAAAARiA7M07jBRe+QGbPgLg1nFgiD26GDBD+wYm93qM+HfwBKYqEbeXVveTsx589OTilT5HP2b6cOfSwCJyU8xU/uKPNYhNGqkGZgPXjIVfvRWFblSX822hnMBOYzdCroarsdUCom4NMlFvAQeZAQ6CtZUkXSKAizYCdx5yeHjjkveAg==",
     "verificationMethod": "did:example:489398593#test"
   }
 }

--- a/__tests__/__fixtures__/data/test_proof_nested_vc_document.json
+++ b/__tests__/__fixtures__/data/test_proof_nested_vc_document.json
@@ -17,12 +17,13 @@
     }
   },
   "issuanceDate": "2020-03-10T04:24:12.164Z",
+  "issuer": "did:example:489398593",
   "proof": {
     "type": "BbsBlsSignatureProof2020",
-    "created": "2020-12-14T03:11:30Z",
-    "nonce": "CF69iO3nfvqRsRBNElE8b4wO39SyJHPM7Gg1nExltW5vSfQA1lvDCR/zXX1To0/4NLo=",
+    "created": "2021-04-26T17:55:05Z",
+    "nonce": "Vy7Mup3vFgTcs0NxggmHYMfIf7+ykk/M1a0+wRNjcGukpe/C2Rl7WvN1DVxCg8gvhng=",
     "proofPurpose": "assertionMethod",
-    "proofValue": "AA0f/7dHROgM2jXZiK0UmY5956/26qbbWF1sKgTMLx1NWEJqrE2ptwlREsxxrqZDRy5pxIFeSxDe08yWxDIk7zefzbwHd04hfbs0oaE2e9TMxIhfUZnct5Br7XenOwpZkkW1d7nt/yUFclgLCAIg+8B3UDpsuzv4rAJ3bTvD69nrMJPwC+Ao7meBgPcAaubNirSqrgAAAHSqzxvoLIRtX8mcq90yIHHuAcThiP63ChKE9c49pJboQ5FBA1aiMIIAJ+J7JPZtBGUAAAACIly7gNiA2nXJAVTKNepEQOtdyEU1gqExcaxWhMgX6nBCRGCwypy5lDDj2XWsvcuzPcvrpvaBxIBvTBAVjKDODaExOe1FKwA2t6F80wvt1BrEQpa5mG9YsI7Hw0wwl+c0SekC/WYlVW0oFjdICH+ZsAAAAAJlYX1Br69N/IAemIkmBvU/7bcIGssDcGL4hNzuTe0a8FnXYhUHyYmnMYFgZMv2ht2nMZiSwAugP2y3dFAU99bU",
+    "proofValue": "AA4//7SYcnewiCvH+CG/CwNY4rXdpfZ/9j79GASJFWa6C9jwBzQenfeXtuMBvHCDvmpTqI5Dtf/7O938CV0qEtUTquPrT6stNxnCfJSPYmM78d48LJidPoLhdRjT+QNfj5sM647odR5b9JOMmW43yMUAxkb+A9bGNdixG5OqK3xLSuRHDkTIi1Lu6/x4xgOeR5KALAAAAHSYATbHEjd2sdxY9n7lzdWkta25moSE1UNZBO+B+nSysYlQYO9H9jX0zRrzUaKDnSAAAAACX8oBf2PCWC3U6jtaoRqO2pAmc4nXO2tqsnVm6zNBUmEQlWf32/Cl3VvyB2q9XBGagPDLiyxuDcSkoQRJX4D/M4IRx8LVMhIYPT4O4mDejKuFqFQN1PiVN4W+eR0I8KZ0Jq8QP97CM8/6YFg+fyuxdQAAAAJJotlRjal+sxbNpyVHU70FDv1icZyEFJwGm7HnFFh/iAqjP69KB37eou5Xt1TkM6fgK65gu0e4jTTALpk5tie3",
     "verificationMethod": "did:example:489398593#test"
   }
 }

--- a/__tests__/__fixtures__/data/test_signed_nested_vc_document.json
+++ b/__tests__/__fixtures__/data/test_signed_nested_vc_document.json
@@ -6,6 +6,7 @@
   ],
   "id": "https://example.gov/credentials/3732",
   "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": "did:example:489398593",
   "issuanceDate": "2020-03-10T04:24:12.164Z",
   "credentialSubject": {
     "id": "did:example:489398593",
@@ -18,9 +19,9 @@
   },
   "proof": {
     "type": "BbsBlsSignature2020",
-    "created": "2020-12-14T03:11:30Z",
+    "created": "2021-04-26T17:55:05Z",
     "proofPurpose": "assertionMethod",
-    "proofValue": "sd8eqx9NWOOVXl7MBLmIOUg0GlOvrP2a+sRPHdcKuapZ7r2K6nNNJ//MOmj9ffRqax6THf0TbvmnXiOo1c4kA29aUsGpZSBbIKPsaNhnJ94KzP5e9+Bm4/FIPjn4magC8b8S8+SMjTrAqXuxMg+BEQ==",
+    "proofValue": "t63mgQTFa5eMU0iIpCKtqyuJxC0S7nRE7fJ1g+/YhGnQqTZjAVzdB6mz+B/rEbJFRjoLnV8aJoyX0SXKEZQCZDinxaWksRnSqsDIGz/MVn4ovSqC5zGcApcCidsEO4S77RANaXba6hRHWrjhJGoMPg==",
     "verificationMethod": "did:example:489398593#test"
   }
 }


### PR DESCRIPTION
Updates the test VC objects to be valid VCs. The credentials were missing `issuer` and `issuanceDate` properties meaning it were not valid VCs. 

I'm trying to do interop testing in ACA-Py based on the documents in this repo, but our tooling is failing because of the invalid VCs. This PR just updates the documents (and signatures) 

## Description

<!--- Describe your changes in detail -->

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation has been added / updated (for bug fixes / features)
- [x] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Which merge strategy will you use?

<!-- This indicates to reviewers whether they need to check your commits are ready to be rebased on master or not. -->

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
