### PR TITLE
build: update release process

### DIFF
--- a/.github/workflows/push-master.yaml
+++ b/.github/workflows/push-master.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_test_publish:
     name: Build, test, and publish unstable release
-    if: "! contains(github.event.head_commit.message, '[skip ci]')"
+    if: "! contains(github.event.head_commit.message, 'chore(release): publish')"
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -13,7 +13,7 @@ To create a stable release follow the following steps
    newly created commit
 9. Push the release branch including the newly created tags `git push origin release --tags`
 10. Open a pull request for the release, once approvals have been sought, merge the pull request using rebase,
-    preserving the commit message as `chore(release): publish [skip ci]`
+    preserving the commit message as `chore(release): publish`
 11. Observe the triggering of the `/.github/workflows/release-master.yaml`
 
 **Note** It is important that rebase is used as the strategy for merging a release pull request as this preserves the created release tag.
@@ -27,7 +27,4 @@ An unstable release is triggered on every commit to master, where the `/.github/
 The releases have the following version syntax
 `<current package version + patch version>-unstable.<current git commit reference>`
 
-**Note** The `/.github/workflows/push-master.yaml` will skip if the commit message includes `[skip ci]`
-
-**Note** To skip the automatic release of a new unstable version append `[skip ci]` to the end of the commit message
-that is merged into master.
+**Note** The `/.github/workflows/push-master.yaml` will skip if the commit message includes `chore(release): publish`

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "publish:unstable": "./scripts/publish_unstable.sh",
     "publish:release": "./scripts/publish.sh",
     "version": "conventional-changelog -p angular -i CHANGELOG.md -s && git add CHANGELOG.md",
-    "version:release": "yarn version --minor --message \"chore(release): publish [skip ci]\""
+    "version:release": "yarn version --minor --message \"chore(release): publish\""
   },
   "devDependencies": {
     "@commitlint/cli": "8.3.5",


### PR DESCRIPTION
## Description

Because GH Actions now appear to recognise the [skip ci] convention in the commit message, this cannot be used in the way we were using it for the release process. Hence the release process has been updated accordingly.

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] The commit message(s) follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation has been added / updated (for bug fixes / features)
- [ ] Changes follow the **[contributing](../docs/CONTRIBUTING.md)** document.

## Motivation and Context

See above

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Which merge strategy will you use?

- [x] Squash
- [ ] Rebase (REVIEW COMMITS)
