### PR TITLE
fix: check for existence of proof object

### DIFF
--- a/src/deriveProof.ts
+++ b/src/deriveProof.ts
@@ -113,7 +113,7 @@ export const deriveProof = async (
      * @included tag messes up the canonicalized bytes leading to a bad
      * signature that won't verify.
      **/
-    if (compactProof.proof["@included"]) {
+    if (compactProof.proof?.["@included"]) {
       compactProof.proof = compactProof.proof["@included"];
     }
 


### PR DESCRIPTION
This fixes a null error in situations where proof derivation happens if the reveal frame is empty JSON object `{}`